### PR TITLE
Parse fallback when failing to parse external

### DIFF
--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -224,15 +225,15 @@ func NewGoType(name, importPath string) Typer {
 	}
 }
 
-func NewGoTypeFromExternalType(externalType spec.ExternalReference) Typer {
+func NewGoTypeFromExternalType(externalType spec.ExternalReference) (Typer, error) {
 	if !strings.Contains(externalType.ExternalReference.Name, ":") {
-		return Any
+		return nil, errors.New("did not find expected delimiter in type name")
 	}
 	pathAndName := strings.Split(externalType.ExternalReference.Name, ":")
 	return &goType{
 		name:       pathAndName[1],
 		importPath: externalType.ExternalReference.Package + "." + pathAndName[0],
-	}
+	}, nil
 }
 
 // goType represents a type that is defined in a Go package.

--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -225,6 +225,9 @@ func NewGoType(name, importPath string) Typer {
 }
 
 func NewGoTypeFromExternalType(externalType spec.ExternalReference) Typer {
+	if !strings.Contains(externalType.ExternalReference.Name, ":") {
+		return Any
+	}
 	pathAndName := strings.Split(externalType.ExternalReference.Name, ":")
 	return &goType{
 		name:       pathAndName[1],

--- a/conjure/visitors/conjuretype_visit_external.go
+++ b/conjure/visitors/conjuretype_visit_external.go
@@ -23,7 +23,6 @@ import (
 
 type externalVisitor struct {
 	externalType     spec.ExternalReference
-	fallbackProvider *ConjureTypeProvider
 }
 
 func newExternalVisitor(externalType spec.ExternalReference) ConjureTypeProvider {

--- a/conjure/visitors/conjuretype_visit_external.go
+++ b/conjure/visitors/conjuretype_visit_external.go
@@ -22,7 +22,7 @@ import (
 )
 
 type externalVisitor struct {
-	externalType spec.ExternalReference
+	externalType     spec.ExternalReference
 	fallbackProvider *ConjureTypeProvider
 }
 

--- a/conjure/visitors/conjuretype_visit_external.go
+++ b/conjure/visitors/conjuretype_visit_external.go
@@ -23,14 +23,25 @@ import (
 
 type externalVisitor struct {
 	externalType spec.ExternalReference
+	fallbackProvider *ConjureTypeProvider
 }
 
 func newExternalVisitor(externalType spec.ExternalReference) ConjureTypeProvider {
 	return &externalVisitor{externalType: externalType}
 }
 
-func (p *externalVisitor) ParseType(types.PkgInfo) (types.Typer, error) {
-	return types.NewGoTypeFromExternalType(p.externalType), nil
+func (p *externalVisitor) ParseType(info types.PkgInfo) (types.Typer, error) {
+	t, err := types.NewGoTypeFromExternalType(p.externalType)
+	if err == nil {
+		return t, nil
+	}
+
+	nestedTypeProvider, err := NewConjureTypeProvider(p.externalType.Fallback)
+	if err != nil {
+		return nil, err
+	}
+
+	return nestedTypeProvider.ParseType(info)
 }
 
 func (p *externalVisitor) CollectionInitializationIfNeeded(types.PkgInfo) (*expression.CallExpression, error) {

--- a/conjure/visitors/conjuretype_visit_external.go
+++ b/conjure/visitors/conjuretype_visit_external.go
@@ -22,7 +22,7 @@ import (
 )
 
 type externalVisitor struct {
-	externalType     spec.ExternalReference
+	externalType spec.ExternalReference
 }
 
 func newExternalVisitor(externalType spec.ExternalReference) ConjureTypeProvider {

--- a/conjure/visitors/conjuretype_visit_external_test.go
+++ b/conjure/visitors/conjuretype_visit_external_test.go
@@ -1,0 +1,31 @@
+package visitors
+
+import (
+	"github.com/palantir/conjure-go/conjure-api/conjure/spec"
+	"github.com/palantir/conjure-go/conjure/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+
+func TestExternalTypeFallback(t *testing.T) {
+
+	t.Run("External Fallback", func(t *testing.T) {
+		def := spec.ExternalReference{
+			ExternalReference: spec.TypeName{
+				Name:    "Foo",
+				Package: "com.example.foo",
+			},
+			Fallback: spec.NewTypeFromPrimitive(spec.PrimitiveTypeString),
+		}
+
+		provider := newExternalVisitor(def)
+
+		info := types.NewPkgInfo("", nil)
+		typ, err := provider.ParseType(info)
+
+		assert.Equal(t, err, nil)
+		assert.Equal(t, types.String, typ)
+	})
+
+}

--- a/conjure/visitors/conjuretype_visit_external_test.go
+++ b/conjure/visitors/conjuretype_visit_external_test.go
@@ -1,12 +1,27 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package visitors
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/palantir/conjure-go/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/conjure/types"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
-
 
 func TestExternalTypeFallback(t *testing.T) {
 


### PR DESCRIPTION
Currently we panic if the type name in an external type does not include
a ":" (not required by the spec). Instead of panicing, we now try to parse
the fallback type and return that. Added test that repros the original
issue and confirms fallback to primitive types works.

Addresses #33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/40)
<!-- Reviewable:end -->
