### PR TITLE
Generate request body provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,7 @@
   revision = "10da8023aca66638ce70ae91d94e565b802f759d"
 
 [[projects]]
-  digest = "1:c16cb016436cfcc7d15d9e7a8a49bfe112656615719d53eafe0d0fcfef0facba"
+  digest = "1:954ea9a898c5e99d510dba4475bf43f79171f727de3bac42c6aff241598044e8"
   name = "github.com/palantir/conjure-go-runtime"
   packages = [
     "conjure-go-client/httpclient",
@@ -112,8 +112,8 @@
     "conjure-go-contract/errors",
   ]
   pruneopts = "UT"
-  revision = "e1c6d8ce827bcf2aed8ec3d9d810e2a4d3261c15"
-  version = "0.2.4"
+  revision = "7e2def9031eb80dad0932419c8cecf74dab224d5"
+  version = "0.2.8"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/palantir/conjure-go-runtime"
-  version = "0.2.4"
+  version = "0.2.8"
 
 [[constraint]]
   name = "github.com/palantir/pkg"

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2250,7 +2250,7 @@ import (
 
 // A Markdown description of the service.
 type TestService interface {
-	PutStatus(ctx context.Context, requestArg io.ReadCloser) (io.ReadCloser, error)
+	PutStatus(ctx context.Context, requestArg func() io.ReadCloser) (io.ReadCloser, error)
 }
 
 type TestServiceClient TestService
@@ -2262,12 +2262,12 @@ func NewTestServiceClient(client httpclient.Client) TestServiceClient {
 	return &testServiceClient{client: client}
 }
 
-func (c *testServiceClient) PutStatus(ctx context.Context, requestArg io.ReadCloser) (io.ReadCloser, error) {
+func (c *testServiceClient) PutStatus(ctx context.Context, requestArg func() io.ReadCloser) (io.ReadCloser, error) {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PutStatus"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("PUT"))
 	requestParams = append(requestParams, httpclient.WithPathf("/status"))
-	requestParams = append(requestParams, httpclient.WithRawRequestBody(requestArg))
+	requestParams = append(requestParams, httpclient.WithRawRequestBodyProvider(requestArg))
 	requestParams = append(requestParams, httpclient.WithRawResponseBody())
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -805,7 +805,8 @@ func paramsForEndpoint(endpointDefinition spec.EndpointDefinition, info types.Pk
 		var goType string
 		argName := string(arg.ArgName)
 		if binaryParam {
-			// TODO: explain
+			// special case: "binary" types resolve to []byte, but this indicates a streaming parameter when
+			// specified as the request argument of a service, so use "io.ReadCloser".
 			goType = types.GetBodyType.GoType(info)
 			imports.AddAll(NewStringSet(types.GetBodyType.ImportPaths()...))
 		} else {

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -508,7 +508,7 @@ func serviceStructMethodBodyAST(endpointDefinition spec.EndpointDefinition, retu
 		if isBinaryParam, err := isBinaryType(bodyArgDef.Type); err != nil {
 			return nil, err
 		} else if isBinaryParam {
-			requestFn = "WithRawRequestBody"
+			requestFn = "WithRawRequestBodyProvider"
 		}
 		appendToRequestParamsFn(requestFn, expression.VariableVal(argNameTransform(string(bodyArgDef.ArgName))))
 	}
@@ -805,10 +805,9 @@ func paramsForEndpoint(endpointDefinition spec.EndpointDefinition, info types.Pk
 		var goType string
 		argName := string(arg.ArgName)
 		if binaryParam {
-			// special case: "binary" types resolve to []byte, but this indicates a streaming parameter when
-			// specified as the request argument of a service, so use "io.ReadCloser".
-			goType = types.IOReadCloserType.GoType(info)
-			imports.AddAll(NewStringSet(types.IOReadCloserType.ImportPaths()...))
+			// TODO: explain
+			goType = types.GetBodyType.GoType(info)
+			imports.AddAll(NewStringSet(types.GetBodyType.ImportPaths()...))
 		} else {
 			typer, err := visitors.NewConjureTypeProviderTyper(arg.Type, info)
 			if err != nil {

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/client_builder.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/client_builder.go
@@ -45,8 +45,9 @@ type httpClientBuilder struct {
 	ServiceName string
 
 	// http.Client modifiers
-	Timeout     time.Duration
-	Middlewares []Middleware
+	Timeout           time.Duration
+	Middlewares       []Middleware
+	metricsMiddleware Middleware
 
 	// http.Transport modifiers
 	MaxIdleConns          int
@@ -90,16 +91,13 @@ func NewClient(params ...ClientParam) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	var edm Middleware
 	if b.errorDecoder != nil {
-		middlewares = append(middlewares, errorDecoderMiddleware(b.errorDecoder))
+		edm = errorDecoderMiddleware(b.errorDecoder)
 	}
 
 	if b.maxRetries == 0 {
 		b.maxRetries = 2 * len(b.uris)
-	}
-
-	for _, middleware := range middlewares {
-		client.Transport = wrapTransport(client.Transport, middleware)
 	}
 	return &clientImpl{
 		client:                        *client,
@@ -107,6 +105,9 @@ func NewClient(params ...ClientParam) (Client, error) {
 		maxRetries:                    b.maxRetries,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,
+		middlewares:                   middlewares,
+		metricsMiddleware:             b.metricsMiddleware,
+		errorDecoderMiddleware:        edm,
 	}, nil
 }
 

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/request_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/request_params.go
@@ -16,7 +16,6 @@ package httpclient
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -104,9 +103,30 @@ func WithRequestBody(input interface{}, encoder codecs.Encoder) RequestParam {
 //     input, _ := os.Open("file.txt")
 //     resp, err := client.Do(..., WithRawRequestBody(input), ...)
 //
+// Deprecated: Retries don't include the body for WithRawRequestBody.
+// Use WithRawRequestBodyProvider for full retry support.
 func WithRawRequestBody(input io.ReadCloser) RequestParam {
+	return WithRawRequestBodyProvider(func() io.ReadCloser {
+		return input
+	})
+}
+
+// WithRawRequestBodyProvider uses the io.ReadCloser provided by
+// getBody as the request body. The getBody parameter must not be nil.
+// Example:
+//
+//     provider := func() io.ReadCloser {
+//         input, _ := os.Open("file.txt")
+//         return input
+//     }
+//     resp, err := client.Do(..., WithRawRequestBodyProvider(provider), ...)
+//
+func WithRawRequestBodyProvider(getBody func() io.ReadCloser) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		b.bodyMiddleware.requestInput = input
+		if getBody == nil {
+			return werror.Error("getBody can not be nil")
+		}
+		b.bodyMiddleware.requestInput = getBody()
 		b.bodyMiddleware.requestEncoder = nil
 		b.headers.Set("Content-Type", "application/octet-stream")
 		return nil
@@ -175,12 +195,21 @@ func WithCompressedRequest(input interface{}, codec codecs.Codec) RequestParam {
 	})
 }
 
-// WithBasicAuth sets the request's Authorization header to use HTTP Basic Authentication with the provided username and
-// password.
-func WithBasicAuth(username, password string) RequestParam {
+// WithRequestErrorDecoder sets an ErrorDecoder to use for this request only. It will take precedence over any
+// ErrorDecoder set on the client. If this request-scoped ErrorDecoder does not handle the response, the client-scoped
+// ErrorDecoder will be consulted in the usual way.
+func WithRequestErrorDecoder(errorDecoder ErrorDecoder) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		basicAuthBytes := []byte(username + ":" + password)
-		b.headers.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(basicAuthBytes))
+		b.errorDecoderMiddleware = errorDecoderMiddleware(errorDecoder)
+		return nil
+	})
+}
+
+// WithRequestBasicAuth sets the request's Authorization header to use HTTP Basic Authentication with the provided
+// username and password for this request only and takes precedence over any client-scoped authorization.
+func WithRequestBasicAuth(username, password string) RequestParam {
+	return requestParamFunc(func(b *requestBuilder) error {
+		setBasicAuth(b.headers, username, password)
 		return nil
 	})
 }

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -52,7 +52,7 @@ func errorDecoderMiddleware(errorDecoder ErrorDecoder) Middleware {
 
 // restErrorDecoder is our default error decoder.
 // It handles responses of status code >= 400. In this case,
-// we create and return a zerror with the 'statusCode' parameter
+// we create and return a werror with the 'statusCode' parameter
 // set to the integer value from the response.
 //
 // Use StatusCodeFromError(err) to retrieve the code from the error,
@@ -70,8 +70,12 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	return werror.Error("server returned a status >= 400", werror.SafeParam("statusCode", resp.StatusCode))
 }
 
-// StatusCodeFromError retrieves the 'statusCode' parameter from the provided zerror.
+// StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
 // If the error is not a werror or does not have the statusCode param, ok is false.
+//
+// The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
+// decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'
+// parameter on the error.
 func StatusCodeFromError(err error) (statusCode int, ok bool) {
 	statusCodeI, ok := werror.ParamFromError(err, "statusCode")
 	if !ok {


### PR DESCRIPTION
Use `WithRawRequestBodyProvider` instead of `WithRawRequestBody` so retries will have the body set.

Fixes: https://github.com/palantir/conjure-go/issues/41

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/42)
<!-- Reviewable:end -->
