### PR TITLE
Use WithRawRequestBodyProvider for binary client requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,7 @@
   revision = "10da8023aca66638ce70ae91d94e565b802f759d"
 
 [[projects]]
-  digest = "1:c16cb016436cfcc7d15d9e7a8a49bfe112656615719d53eafe0d0fcfef0facba"
+  digest = "1:954ea9a898c5e99d510dba4475bf43f79171f727de3bac42c6aff241598044e8"
   name = "github.com/palantir/conjure-go-runtime"
   packages = [
     "conjure-go-client/httpclient",
@@ -112,8 +112,8 @@
     "conjure-go-contract/errors",
   ]
   pruneopts = "UT"
-  revision = "e1c6d8ce827bcf2aed8ec3d9d810e2a4d3261c15"
-  version = "0.2.4"
+  revision = "7e2def9031eb80dad0932419c8cecf74dab224d5"
+  version = "0.2.8"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/palantir/conjure-go-runtime"
-  version = "0.2.4"
+  version = "0.2.8"
 
 [[constraint]]
   name = "github.com/palantir/pkg"

--- a/conjure-go-verifier/conjure/verification/server/services.conjure.go
+++ b/conjure-go-verifier/conjure/verification/server/services.conjure.go
@@ -17,7 +17,7 @@ import (
 	"github.com/palantir/conjure-go/conjure-go-verifier/conjure/verification/types"
 )
 
-type AutoDeserializeService interface {
+type AutoDeserializeServiceClient interface {
 	ReceiveBearerTokenExample(ctx context.Context, indexArg int) (types.BearerTokenExample, error)
 	ReceiveBooleanExample(ctx context.Context, indexArg int) (types.BooleanExample, error)
 	ReceiveDateTimeExample(ctx context.Context, indexArg int) (types.DateTimeExample, error)
@@ -95,7 +95,6 @@ type AutoDeserializeService interface {
 	ReceiveMapEnumExampleAlias(ctx context.Context, indexArg int) (types.MapEnumExampleAlias, error)
 }
 
-type AutoDeserializeServiceClient AutoDeserializeService
 type autoDeserializeServiceClient struct {
 	client httpclient.Client
 }
@@ -1529,7 +1528,7 @@ func (c *autoDeserializeServiceClient) ReceiveMapEnumExampleAlias(ctx context.Co
 	return *returnVal, nil
 }
 
-type SinglePathParamService interface {
+type SinglePathParamServiceClient interface {
 	PathParamBoolean(ctx context.Context, indexArg int, paramArg bool) error
 	PathParamDatetime(ctx context.Context, indexArg int, paramArg datetime.DateTime) error
 	PathParamDouble(ctx context.Context, indexArg int, paramArg float64) error
@@ -1541,7 +1540,6 @@ type SinglePathParamService interface {
 	PathParamAliasString(ctx context.Context, indexArg int, paramArg types.AliasString) error
 }
 
-type SinglePathParamServiceClient SinglePathParamService
 type singlePathParamServiceClient struct {
 	client httpclient.Client
 }
@@ -1667,7 +1665,7 @@ func (c *singlePathParamServiceClient) PathParamAliasString(ctx context.Context,
 	return nil
 }
 
-type SingleQueryParamService interface {
+type SingleQueryParamServiceClient interface {
 	QueryParamBoolean(ctx context.Context, indexArg int, someQueryArg bool) error
 	QueryParamDouble(ctx context.Context, indexArg int, someQueryArg float64) error
 	QueryParamInteger(ctx context.Context, indexArg int, someQueryArg int) error
@@ -1679,7 +1677,6 @@ type SingleQueryParamService interface {
 	QueryParamAliasString(ctx context.Context, indexArg int, someQueryArg types.AliasString) error
 }
 
-type SingleQueryParamServiceClient SingleQueryParamService
 type singleQueryParamServiceClient struct {
 	client httpclient.Client
 }
@@ -1834,7 +1831,7 @@ func (c *singleQueryParamServiceClient) QueryParamAliasString(ctx context.Contex
 	return nil
 }
 
-type SingleHeaderService interface {
+type SingleHeaderServiceClient interface {
 	HeaderBearertoken(ctx context.Context, indexArg int, headerArg bearertoken.Token) error
 	HeaderBoolean(ctx context.Context, indexArg int, headerArg bool) error
 	HeaderDatetime(ctx context.Context, indexArg int, headerArg datetime.DateTime) error
@@ -1848,7 +1845,6 @@ type SingleHeaderService interface {
 	HeaderAliasString(ctx context.Context, indexArg int, headerArg types.AliasString) error
 }
 
-type SingleHeaderServiceClient SingleHeaderService
 type singleHeaderServiceClient struct {
 	client httpclient.Client
 }
@@ -2011,12 +2007,11 @@ func (c *singleHeaderServiceClient) HeaderAliasString(ctx context.Context, index
 	return nil
 }
 
-type AutoDeserializeConfirmService interface {
+type AutoDeserializeConfirmServiceClient interface {
 	// Send the response received for positive test cases here to verify that it has been serialized and deserialized properly.
 	Confirm(ctx context.Context, endpointArg EndpointName, indexArg int, bodyArg interface{}) error
 }
 
-type AutoDeserializeConfirmServiceClient AutoDeserializeConfirmService
 type autoDeserializeConfirmServiceClient struct {
 	client httpclient.Client
 }

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -246,6 +246,12 @@ func (c *outputFileCollector) VisitService(serviceDefinition spec.ServiceDefinit
 	// Possible add servers
 	info = c.servers.Info
 	if c.cfg.GenerateServer {
+		serverInterfaces, err := AstForServerInterfaces(serviceDefinition, info)
+		if err != nil {
+			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
+		}
+		c.servers.Decls = append(c.servers.Decls, serverInterfaces...)
+
 		routeReg, err := ASTForServerRouteRegistration(serviceDefinition, info)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -246,7 +246,7 @@ func (c *outputFileCollector) VisitService(serviceDefinition spec.ServiceDefinit
 	// Possible add servers
 	info = c.servers.Info
 	if c.cfg.GenerateServer {
-		serverInterfaces, err := AstForServerInterfaces(serviceDefinition, info)
+		serverInterfaces, err := AstForServerInterface(serviceDefinition, info)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
 		}

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -901,7 +901,7 @@ import (
 )
 
 // A Markdown description of the service.
-type TestService interface {
+type TestServiceClient interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context, authHeader bearertoken.Token) (map[string]int, error)
 	CreateDataset(ctx context.Context, cookieToken bearertoken.Token, requestArg string) error
@@ -909,7 +909,6 @@ type TestService interface {
 	QueryParams(ctx context.Context, inputArg string, repsArg int) error
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }
@@ -984,15 +983,13 @@ func (c *testServiceClient) QueryParams(ctx context.Context, inputArg string, re
 }
 
 // A Markdown description of the service.
-type TestServiceWithAuth interface {
+type TestServiceClientWithAuth interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context) (map[string]int, error)
 	CreateDataset(ctx context.Context, requestArg string) error
 	StreamResponse(ctx context.Context) (io.ReadCloser, error)
 	QueryParams(ctx context.Context, inputArg string, repsArg int) error
 }
-
-type TestServiceClientWithAuth TestServiceWithAuth
 
 func NewTestServiceClientWithAuth(client TestServiceClient, authHeader bearertoken.Token, cookieToken bearertoken.Token) TestServiceClientWithAuth {
 	return &testServiceClientWithAuth{client: client, authHeader: authHeader, cookieToken: cookieToken}
@@ -1071,12 +1068,11 @@ import (
 )
 
 // A Markdown description of the service.
-type TestService interface {
+type TestServiceClient interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context) (map[string]int, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }
@@ -1220,12 +1216,11 @@ import (
 )
 
 // A Markdown description of the service.
-type TestService interface {
+type TestServiceClient interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context, authHeader bearertoken.Token) (map[string]datasets.BackingFileSystem, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }
@@ -1254,12 +1249,10 @@ func (c *testServiceClient) GetFileSystems(ctx context.Context, authHeader beare
 }
 
 // A Markdown description of the service.
-type TestServiceWithAuth interface {
+type TestServiceClientWithAuth interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context) (map[string]datasets.BackingFileSystem, error)
 }
-
-type TestServiceClientWithAuth TestServiceWithAuth
 
 func NewTestServiceClientWithAuth(client TestServiceClient, authHeader bearertoken.Token) TestServiceClientWithAuth {
 	return &testServiceClientWithAuth{client: client, authHeader: authHeader}
@@ -2249,11 +2242,10 @@ import (
 )
 
 // A Markdown description of the service.
-type TestService interface {
-	PutStatus(ctx context.Context, requestArg io.ReadCloser) (io.ReadCloser, error)
+type TestServiceClient interface {
+	PutStatus(ctx context.Context, requestArg func() io.ReadCloser) (io.ReadCloser, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }
@@ -2262,12 +2254,12 @@ func NewTestServiceClient(client httpclient.Client) TestServiceClient {
 	return &testServiceClient{client: client}
 }
 
-func (c *testServiceClient) PutStatus(ctx context.Context, requestArg io.ReadCloser) (io.ReadCloser, error) {
+func (c *testServiceClient) PutStatus(ctx context.Context, requestArg func() io.ReadCloser) (io.ReadCloser, error) {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PutStatus"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("PUT"))
 	requestParams = append(requestParams, httpclient.WithPathf("/status"))
-	requestParams = append(requestParams, httpclient.WithRawRequestBody(requestArg))
+	requestParams = append(requestParams, httpclient.WithRawRequestBodyProvider(requestArg))
 	requestParams = append(requestParams, httpclient.WithRawResponseBody())
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -212,7 +212,7 @@ func getResourceFunction(endpointDefinition spec.EndpointDefinition) string {
 	}
 }
 
-func AstForServerInterfaces(serviceDefinition spec.ServiceDefinition, info types.PkgInfo) ([]astgen.ASTDecl, error) {
+func AstForServerInterface(serviceDefinition spec.ServiceDefinition, info types.PkgInfo) ([]astgen.ASTDecl, error) {
 	serviceName := serviceDefinition.ServiceName.Name
 	isClient := false
 	interfaceAST, _, err := serviceInterfaceAST(serviceDefinition, info, false, isClient)
@@ -221,18 +221,6 @@ func AstForServerInterfaces(serviceDefinition spec.ServiceDefinition, info types
 	}
 	components := []astgen.ASTDecl{
 		interfaceAST,
-	}
-	hasHeaderAuth, hasCookieAuth, err := hasAuth(serviceDefinition.Endpoints)
-	if err != nil {
-		return nil, err
-	}
-	if hasHeaderAuth || hasCookieAuth {
-		// at least one endpoint uses authentication: define decorator structures
-		withAuthInterfaceAST, _, err := serviceInterfaceAST(serviceDefinition, info, true, isClient)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to generate interface with auth for service %q", serviceName)
-		}
-		components = append(components, withAuthInterfaceAST)
 	}
 	return components, nil
 }

--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -68,11 +68,8 @@ var (
 		importPath: "io",
 	}
 	GetBodyType Typer = &funcType{
-		outputs: []goType{
-			{
-				name:       "ReadCloser",
-				importPath: "io",
-			},
+		outputs: []Typer{
+			IOReadCloserType,
 		},
 	}
 	Bearertoken Typer = &goType{
@@ -277,22 +274,34 @@ func (t *goType) ImportPaths() []string {
 }
 
 type funcType struct {
-	inputs  []goType
-	outputs []goType
+	inputs  []Typer
+	outputs []Typer
 }
 
 func (f *funcType) GoType(info PkgInfo) string {
 	inputs := goTypes(f.inputs, info)
 	outputs := goTypes(f.outputs, info)
-	return fmt.Sprintf("func(%s) %s", strings.Join(inputs, ", "), strings.Join(outputs, ", "))
+	return fmt.Sprintf("func(%s)%s", strings.Join(inputs, ", "), getOutputString(outputs))
 }
 
-func goTypes(types []goType, info PkgInfo) []string {
+func goTypes(types []Typer, info PkgInfo) []string {
 	result := make([]string, 0, len(types))
 	for _, t := range types {
 		result = append(result, t.GoType(info))
 	}
 	return result
+}
+
+func getOutputString(outputs []string) string {
+	if len(outputs) == 0 {
+		return ""
+	}
+	// functions with one output look better without parentheses
+	if len(outputs) == 1 {
+		return " " + outputs[0]
+	}
+	// functions with two or more need parentheses
+	return fmt.Sprintf(" (%s)", strings.Join(outputs, ", "))
 }
 
 func (f *funcType) ImportPaths() []string {

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -170,7 +170,7 @@ import (
 )
 
 // A Markdown description of the service.
-type ExampleService interface {
+type ExampleServiceClient interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context, authHeader bearertoken.Token) (map[string]datasets.BackingFileSystem, error)
 	CreateDataset(ctx context.Context, cookieToken bearertoken.Token, requestArg api.CreateDatasetRequest) (datasets.Dataset, error)
@@ -185,7 +185,6 @@ type ExampleService interface {
 	TestInteger(ctx context.Context, authHeader bearertoken.Token) (int, error)
 }
 
-type ExampleServiceClient ExampleService
 type exampleServiceClient struct {
 	client httpclient.Client
 }
@@ -380,7 +379,7 @@ func (c *exampleServiceClient) TestInteger(ctx context.Context, authHeader beare
 }
 
 // A Markdown description of the service.
-type ExampleServiceWithAuth interface {
+type ExampleServiceClientWithAuth interface {
 	// Returns a mapping from file system id to backing file system configuration.
 	GetFileSystems(ctx context.Context) (map[string]datasets.BackingFileSystem, error)
 	CreateDataset(ctx context.Context, requestArg api.CreateDatasetRequest) (datasets.Dataset, error)
@@ -394,8 +393,6 @@ type ExampleServiceWithAuth interface {
 	TestDouble(ctx context.Context) (float64, error)
 	TestInteger(ctx context.Context) (int, error)
 }
-
-type ExampleServiceClientWithAuth ExampleServiceWithAuth
 
 func NewExampleServiceClientWithAuth(client ExampleServiceClient, authHeader bearertoken.Token, cookieToken bearertoken.Token) ExampleServiceClientWithAuth {
 	return &exampleServiceClientWithAuth{client: client, authHeader: authHeader, cookieToken: cookieToken}

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-contract/codecs"
@@ -12,6 +13,20 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
+
+type BothAuthService interface {
+	Default(ctx context.Context, authHeader bearertoken.Token) (string, error)
+	Cookie(ctx context.Context, cookieToken bearertoken.Token) error
+	None(ctx context.Context) error
+	WithArg(ctx context.Context, authHeader bearertoken.Token, argArg string) error
+}
+
+type BothAuthServiceWithAuth interface {
+	Default(ctx context.Context) (string, error)
+	Cookie(ctx context.Context) error
+	None(ctx context.Context) error
+	WithArg(ctx context.Context, argArg string) error
+}
 
 // RegisterRoutesBothAuthService registers handlers for the BothAuthService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.
@@ -77,6 +92,14 @@ func (b *bothAuthServiceHandler) HandleWithArg(rw http.ResponseWriter, req *http
 	return b.impl.WithArg(req.Context(), bearertoken.Token(authHeader), arg)
 }
 
+type HeaderAuthService interface {
+	Default(ctx context.Context, authHeader bearertoken.Token) (string, error)
+}
+
+type HeaderAuthServiceWithAuth interface {
+	Default(ctx context.Context) (string, error)
+}
+
 // RegisterRoutesHeaderAuthService registers handlers for the HeaderAuthService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.
 // impl provides an implementation of each endpoint, which can assume the request parameters have been parsed
@@ -105,6 +128,14 @@ func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *ht
 	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
+}
+
+type CookieAuthService interface {
+	Cookie(ctx context.Context, cookieToken bearertoken.Token) error
+}
+
+type CookieAuthServiceWithAuth interface {
+	Cookie(ctx context.Context) error
 }
 
 // RegisterRoutesCookieAuthService registers handlers for the CookieAuthService endpoints with a witchcraft wrouter.

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -21,13 +21,6 @@ type BothAuthService interface {
 	WithArg(ctx context.Context, authHeader bearertoken.Token, argArg string) error
 }
 
-type BothAuthServiceWithAuth interface {
-	Default(ctx context.Context) (string, error)
-	Cookie(ctx context.Context) error
-	None(ctx context.Context) error
-	WithArg(ctx context.Context, argArg string) error
-}
-
 // RegisterRoutesBothAuthService registers handlers for the BothAuthService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.
 // impl provides an implementation of each endpoint, which can assume the request parameters have been parsed
@@ -96,10 +89,6 @@ type HeaderAuthService interface {
 	Default(ctx context.Context, authHeader bearertoken.Token) (string, error)
 }
 
-type HeaderAuthServiceWithAuth interface {
-	Default(ctx context.Context) (string, error)
-}
-
 // RegisterRoutesHeaderAuthService registers handlers for the HeaderAuthService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.
 // impl provides an implementation of each endpoint, which can assume the request parameters have been parsed
@@ -132,10 +121,6 @@ func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *ht
 
 type CookieAuthService interface {
 	Cookie(ctx context.Context, cookieToken bearertoken.Token) error
-}
-
-type CookieAuthServiceWithAuth interface {
-	Cookie(ctx context.Context) error
 }
 
 // RegisterRoutesCookieAuthService registers handlers for the CookieAuthService endpoints with a witchcraft wrouter.

--- a/integration_test/testgenerated/auth/api/services.conjure.go
+++ b/integration_test/testgenerated/auth/api/services.conjure.go
@@ -10,14 +10,13 @@ import (
 	"github.com/palantir/pkg/bearertoken"
 )
 
-type BothAuthService interface {
+type BothAuthServiceClient interface {
 	Default(ctx context.Context, authHeader bearertoken.Token) (string, error)
 	Cookie(ctx context.Context, cookieToken bearertoken.Token) error
 	None(ctx context.Context) error
 	WithArg(ctx context.Context, authHeader bearertoken.Token, argArg string) error
 }
 
-type BothAuthServiceClient BothAuthService
 type bothAuthServiceClient struct {
 	client httpclient.Client
 }
@@ -88,14 +87,12 @@ func (c *bothAuthServiceClient) WithArg(ctx context.Context, authHeader bearerto
 	return nil
 }
 
-type BothAuthServiceWithAuth interface {
+type BothAuthServiceClientWithAuth interface {
 	Default(ctx context.Context) (string, error)
 	Cookie(ctx context.Context) error
 	None(ctx context.Context) error
 	WithArg(ctx context.Context, argArg string) error
 }
-
-type BothAuthServiceClientWithAuth BothAuthServiceWithAuth
 
 func NewBothAuthServiceClientWithAuth(client BothAuthServiceClient, authHeader bearertoken.Token, cookieToken bearertoken.Token) BothAuthServiceClientWithAuth {
 	return &bothAuthServiceClientWithAuth{client: client, authHeader: authHeader, cookieToken: cookieToken}
@@ -123,11 +120,10 @@ func (c *bothAuthServiceClientWithAuth) WithArg(ctx context.Context, argArg stri
 	return c.client.WithArg(ctx, c.authHeader, argArg)
 }
 
-type HeaderAuthService interface {
+type HeaderAuthServiceClient interface {
 	Default(ctx context.Context, authHeader bearertoken.Token) (string, error)
 }
 
-type HeaderAuthServiceClient HeaderAuthService
 type headerAuthServiceClient struct {
 	client httpclient.Client
 }
@@ -156,11 +152,9 @@ func (c *headerAuthServiceClient) Default(ctx context.Context, authHeader bearer
 	return *returnVal, nil
 }
 
-type HeaderAuthServiceWithAuth interface {
+type HeaderAuthServiceClientWithAuth interface {
 	Default(ctx context.Context) (string, error)
 }
-
-type HeaderAuthServiceClientWithAuth HeaderAuthServiceWithAuth
 
 func NewHeaderAuthServiceClientWithAuth(client HeaderAuthServiceClient, authHeader bearertoken.Token) HeaderAuthServiceClientWithAuth {
 	return &headerAuthServiceClientWithAuth{client: client, authHeader: authHeader}
@@ -175,11 +169,10 @@ func (c *headerAuthServiceClientWithAuth) Default(ctx context.Context) (string, 
 	return c.client.Default(ctx, c.authHeader)
 }
 
-type CookieAuthService interface {
+type CookieAuthServiceClient interface {
 	Cookie(ctx context.Context, cookieToken bearertoken.Token) error
 }
 
-type CookieAuthServiceClient CookieAuthService
 type cookieAuthServiceClient struct {
 	client httpclient.Client
 }
@@ -202,11 +195,9 @@ func (c *cookieAuthServiceClient) Cookie(ctx context.Context, cookieToken bearer
 	return nil
 }
 
-type CookieAuthServiceWithAuth interface {
+type CookieAuthServiceClientWithAuth interface {
 	Cookie(ctx context.Context) error
 }
-
-type CookieAuthServiceClientWithAuth CookieAuthServiceWithAuth
 
 func NewCookieAuthServiceClientWithAuth(client CookieAuthServiceClient, cookieToken bearertoken.Token) CookieAuthServiceClientWithAuth {
 	return &cookieAuthServiceClientWithAuth{client: client, cookieToken: cookieToken}

--- a/integration_test/testgenerated/client/api/servers.conjure.go
+++ b/integration_test/testgenerated/client/api/servers.conjure.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"context"
+	"io"
 	"net/http"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-contract/codecs"
@@ -11,6 +13,13 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
+
+type TestService interface {
+	Echo(ctx context.Context) error
+	PathParam(ctx context.Context, paramArg string) error
+	Bytes(ctx context.Context) (CustomObject, error)
+	Binary(ctx context.Context) (io.ReadCloser, error)
+}
 
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.

--- a/integration_test/testgenerated/client/api/services.conjure.go
+++ b/integration_test/testgenerated/client/api/services.conjure.go
@@ -11,14 +11,13 @@ import (
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
 )
 
-type TestService interface {
+type TestServiceClient interface {
 	Echo(ctx context.Context) error
 	PathParam(ctx context.Context, paramArg string) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	Binary(ctx context.Context) (io.ReadCloser, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-contract/codecs"
@@ -11,6 +12,10 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
+
+type TestService interface {
+	Echo(ctx context.Context, inputArg string) (string, error)
+}
 
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.

--- a/integration_test/testgenerated/post/api/services.conjure.go
+++ b/integration_test/testgenerated/post/api/services.conjure.go
@@ -9,11 +9,10 @@ import (
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
 )
 
-type TestService interface {
+type TestServiceClient interface {
 	Echo(ctx context.Context, inputArg string) (string, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }

--- a/integration_test/testgenerated/queryparam/api/servers.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/servers.conjure.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -12,6 +13,10 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
+
+type TestService interface {
+	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, lastParamArg *string) (string, error)
+}
 
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.

--- a/integration_test/testgenerated/queryparam/api/services.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/services.conjure.go
@@ -10,11 +10,10 @@ import (
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
 )
 
-type TestService interface {
+type TestServiceClient interface {
 	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, lastParamArg *string) (string, error)
 }
 
-type TestServiceClient TestService
 type testServiceClient struct {
 	client httpclient.Client
 }

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -15,6 +17,26 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
+
+type TestService interface {
+	Echo(ctx context.Context, cookieToken bearertoken.Token) error
+	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
+	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
+	Bytes(ctx context.Context) (CustomObject, error)
+	GetBinary(ctx context.Context) (io.ReadCloser, error)
+	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
+	PutBinary(ctx context.Context, myBytesArg io.ReadCloser) error
+}
+
+type TestServiceWithAuth interface {
+	Echo(ctx context.Context) error
+	GetPathParam(ctx context.Context, myPathParamArg string) error
+	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
+	Bytes(ctx context.Context) (CustomObject, error)
+	GetBinary(ctx context.Context) (io.ReadCloser, error)
+	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
+	PutBinary(ctx context.Context, myBytesArg io.ReadCloser) error
+}
 
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -28,16 +28,6 @@ type TestService interface {
 	PutBinary(ctx context.Context, myBytesArg io.ReadCloser) error
 }
 
-type TestServiceWithAuth interface {
-	Echo(ctx context.Context) error
-	GetPathParam(ctx context.Context, myPathParamArg string) error
-	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	Bytes(ctx context.Context) (CustomObject, error)
-	GetBinary(ctx context.Context) (io.ReadCloser, error)
-	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
-	PutBinary(ctx context.Context, myBytesArg io.ReadCloser) error
-}
-
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
 // This should typically be called in a witchcraft server's InitFunc.
 // impl provides an implementation of each endpoint, which can assume the request parameters have been parsed

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/client_builder.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/client_builder.go
@@ -45,8 +45,9 @@ type httpClientBuilder struct {
 	ServiceName string
 
 	// http.Client modifiers
-	Timeout     time.Duration
-	Middlewares []Middleware
+	Timeout           time.Duration
+	Middlewares       []Middleware
+	metricsMiddleware Middleware
 
 	// http.Transport modifiers
 	MaxIdleConns          int
@@ -90,16 +91,13 @@ func NewClient(params ...ClientParam) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	var edm Middleware
 	if b.errorDecoder != nil {
-		middlewares = append(middlewares, errorDecoderMiddleware(b.errorDecoder))
+		edm = errorDecoderMiddleware(b.errorDecoder)
 	}
 
 	if b.maxRetries == 0 {
 		b.maxRetries = 2 * len(b.uris)
-	}
-
-	for _, middleware := range middlewares {
-		client.Transport = wrapTransport(client.Transport, middleware)
 	}
 	return &clientImpl{
 		client:                        *client,
@@ -107,6 +105,9 @@ func NewClient(params ...ClientParam) (Client, error) {
 		maxRetries:                    b.maxRetries,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,
+		middlewares:                   middlewares,
+		metricsMiddleware:             b.metricsMiddleware,
+		errorDecoderMiddleware:        edm,
 	}, nil
 }
 

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/request_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/request_params.go
@@ -16,7 +16,6 @@ package httpclient
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -104,9 +103,30 @@ func WithRequestBody(input interface{}, encoder codecs.Encoder) RequestParam {
 //     input, _ := os.Open("file.txt")
 //     resp, err := client.Do(..., WithRawRequestBody(input), ...)
 //
+// Deprecated: Retries don't include the body for WithRawRequestBody.
+// Use WithRawRequestBodyProvider for full retry support.
 func WithRawRequestBody(input io.ReadCloser) RequestParam {
+	return WithRawRequestBodyProvider(func() io.ReadCloser {
+		return input
+	})
+}
+
+// WithRawRequestBodyProvider uses the io.ReadCloser provided by
+// getBody as the request body. The getBody parameter must not be nil.
+// Example:
+//
+//     provider := func() io.ReadCloser {
+//         input, _ := os.Open("file.txt")
+//         return input
+//     }
+//     resp, err := client.Do(..., WithRawRequestBodyProvider(provider), ...)
+//
+func WithRawRequestBodyProvider(getBody func() io.ReadCloser) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		b.bodyMiddleware.requestInput = input
+		if getBody == nil {
+			return werror.Error("getBody can not be nil")
+		}
+		b.bodyMiddleware.requestInput = getBody()
 		b.bodyMiddleware.requestEncoder = nil
 		b.headers.Set("Content-Type", "application/octet-stream")
 		return nil
@@ -175,12 +195,21 @@ func WithCompressedRequest(input interface{}, codec codecs.Codec) RequestParam {
 	})
 }
 
-// WithBasicAuth sets the request's Authorization header to use HTTP Basic Authentication with the provided username and
-// password.
-func WithBasicAuth(username, password string) RequestParam {
+// WithRequestErrorDecoder sets an ErrorDecoder to use for this request only. It will take precedence over any
+// ErrorDecoder set on the client. If this request-scoped ErrorDecoder does not handle the response, the client-scoped
+// ErrorDecoder will be consulted in the usual way.
+func WithRequestErrorDecoder(errorDecoder ErrorDecoder) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		basicAuthBytes := []byte(username + ":" + password)
-		b.headers.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(basicAuthBytes))
+		b.errorDecoderMiddleware = errorDecoderMiddleware(errorDecoder)
+		return nil
+	})
+}
+
+// WithRequestBasicAuth sets the request's Authorization header to use HTTP Basic Authentication with the provided
+// username and password for this request only and takes precedence over any client-scoped authorization.
+func WithRequestBasicAuth(username, password string) RequestParam {
+	return requestParamFunc(func(b *requestBuilder) error {
+		setBasicAuth(b.headers, username, password)
 		return nil
 	})
 }

--- a/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -52,7 +52,7 @@ func errorDecoderMiddleware(errorDecoder ErrorDecoder) Middleware {
 
 // restErrorDecoder is our default error decoder.
 // It handles responses of status code >= 400. In this case,
-// we create and return a zerror with the 'statusCode' parameter
+// we create and return a werror with the 'statusCode' parameter
 // set to the integer value from the response.
 //
 // Use StatusCodeFromError(err) to retrieve the code from the error,
@@ -70,8 +70,12 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	return werror.Error("server returned a status >= 400", werror.SafeParam("statusCode", resp.StatusCode))
 }
 
-// StatusCodeFromError retrieves the 'statusCode' parameter from the provided zerror.
+// StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
 // If the error is not a werror or does not have the statusCode param, ok is false.
+//
+// The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
+// decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'
+// parameter on the error.
 func StatusCodeFromError(err error) (statusCode int, ok bool) {
 	statusCodeI, ok := werror.ParamFromError(err, "statusCode")
 	if !ok {


### PR DESCRIPTION
Use `WithRawRequestBodyProvider` instead of `WithRawRequestBody` so retries will have the body set.

Note:  Formerly the generated server code used the service interface, but now they each have their own interfaces. The interface used by the server hasn't changed at all, but the binary case for the service has been modified.

Fixes: https://github.com/palantir/conjure-go/issues/41

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/43)
<!-- Reviewable:end -->
