### PR TITLE
Update build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ working_dir: &working_dir
 darwin-linux-no-cgo: &darwin-linux-no-cgo
   <<: *working_dir
   docker:
-    - image: nmiyake/go:go-darwin-linux-no-cgo-1.11.2-t138
+    - image: nmiyake/go:go-darwin-linux-no-cgo-1.11.4-java-11-t144
       environment:
         CGO_ENABLED: 0
 
@@ -44,7 +44,7 @@ jobs:
   verify:
     <<: *working_dir
     docker:
-      - image: nmiyake/go:alpine-go-1.11-java-8u171-t134
+      - image: nmiyake/go:alpine-go-1.11.4-java-8u181-t144
         environment:
           CGO_ENABLED: 0
     steps:
@@ -70,7 +70,7 @@ jobs:
   conjure-verifier:
     <<: *working_dir
     docker:
-      - image: nmiyake/go:go-darwin-linux-no-cgo-1.11-t134
+      - image: nmiyake/go:go-darwin-linux-no-cgo-1.11.4-java-11-t144
         environment:
           CGO_ENABLED: 0
       - image: palantirtechnologies/conjure-verification-server:0.16.2


### PR DESCRIPTION
Before this PR:
-
- Build images in the circle config were on go 1.11

After this PR:
-
- Build images in the circle config are now on go 1.11.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/49)
<!-- Reviewable:end -->
