### PR TITLE
errorwriter: escape go keywords in constructor params

### DIFF
--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -77,12 +77,12 @@ func astForError(errorDefinition spec.ErrorDefinition, info types.PkgInfo) ([]as
 		}
 		goType := typer.GoType(info)
 		constructorParams = append(constructorParams, &expression.FuncParam{
-			Names: []string{string(fieldDefinition.FieldName)},
+			Names: []string{transforms.SafeName(string(fieldDefinition.FieldName))},
 			Type:  expression.Type(goType),
 		})
 		paramToFieldAssignments = append(paramToFieldAssignments, expression.NewKeyValue(
 			transforms.Export(string(fieldDefinition.FieldName)),
-			expression.VariableVal(string(fieldDefinition.FieldName)),
+			expression.VariableVal(transforms.SafeName(string(fieldDefinition.FieldName))),
 		))
 	}
 	decls = append(decls,

--- a/godel/config/godel.yml
+++ b/godel/config/godel.yml
@@ -20,4 +20,5 @@ exclude:
     - "godel"
     - "conjure-api/conjure"
     - "conjure-go-verifier/conjure"
+    - "integration_test/testgenerated/errors/api"
     - "integration_test/testgenerated/objects/api"

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -16,7 +16,9 @@ type myNotFound struct {
 	// This is safeArgA doc.
 	SafeArgA Basic `json:"safeArgA" conjure-docs:"This is safeArgA doc."`
 	// This is safeArgB doc.
-	SafeArgB   []int   `json:"safeArgB" conjure-docs:"This is safeArgB doc."`
+	SafeArgB []int `json:"safeArgB" conjure-docs:"This is safeArgB doc."`
+	// A field named with a go keyword
+	Type       string  `json:"type" conjure-docs:"A field named with a go keyword"`
 	UnsafeArgA string  `json:"unsafeArgA"`
 	UnsafeArgB *string `json:"unsafeArgB"`
 }
@@ -59,8 +61,8 @@ func (o *myNotFound) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // NewMyNotFound returns new instance of MyNotFound error.
-func NewMyNotFound(safeArgA Basic, safeArgB []int, unsafeArgA string, unsafeArgB *string) *MyNotFound {
-	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgA, SafeArgB: safeArgB, UnsafeArgA: unsafeArgA, UnsafeArgB: unsafeArgB}}
+func NewMyNotFound(safeArgA Basic, safeArgB []int, type_ string, unsafeArgA string, unsafeArgB *string) *MyNotFound {
+	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgA, SafeArgB: safeArgB, Type: type_, UnsafeArgA: unsafeArgA, UnsafeArgB: unsafeArgB}}
 }
 
 // MyNotFound is an error type.
@@ -92,7 +94,7 @@ func (e *MyNotFound) InstanceID() uuid.UUID {
 
 // Parameters returns a set of named parameters detailing this particular error instance.
 func (e *MyNotFound) Parameters() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
 }
 
 func (e MyNotFound) MarshalJSON() ([]byte, error) {

--- a/integration_test/testgenerated/errors/errors.yml
+++ b/integration_test/testgenerated/errors/errors.yml
@@ -13,6 +13,9 @@ types:
           safeArgB:
             type: list<integer>
             docs: This is safeArgB doc.
+          type:
+            type: string
+            docs: A field named with a go keyword
         unsafe-args:
           unsafeArgA: string
           unsafeArgB: optional<string>

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -34,6 +34,7 @@ var testError = api.NewMyNotFound(
 		Data: "some data",
 	},
 	[]int{1, 2, 3},
+	"type",
 	"something",
 	nil,
 )
@@ -51,6 +52,7 @@ var testJSON = fmt.Sprintf(`{
       2,
       3
     ],
+    "type": "type",
     "unsafeArgA": "something",
     "unsafeArgB": null
   }
@@ -63,6 +65,7 @@ func TestError_ErrorMethods(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"safeArgA":   testError.SafeArgA,
 		"safeArgB":   testError.SafeArgB,
+		"type":       testError.Type,
 		"unsafeArgA": testError.UnsafeArgA,
 		"unsafeArgB": testError.UnsafeArgB,
 	}, testError.Parameters())

--- a/integration_test/testgenerated/objects/api/structs.conjure.go
+++ b/integration_test/testgenerated/objects/api/structs.conjure.go
@@ -164,3 +164,52 @@ func (o *Collections) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	return safejson.Unmarshal(jsonBytes, *&o)
 }
+
+// A type using go keywords
+type Type struct {
+	Type []string          `json:"type"`
+	Chan map[string]string `json:"chan"`
+}
+
+func (o Type) MarshalJSON() ([]byte, error) {
+	if o.Type == nil {
+		o.Type = make([]string, 0)
+	}
+	if o.Chan == nil {
+		o.Chan = make(map[string]string, 0)
+	}
+	type TypeAlias Type
+	return safejson.Marshal(TypeAlias(o))
+}
+
+func (o *Type) UnmarshalJSON(data []byte) error {
+	type TypeAlias Type
+	var rawType TypeAlias
+	if err := safejson.Unmarshal(data, &rawType); err != nil {
+		return err
+	}
+	if rawType.Type == nil {
+		rawType.Type = make([]string, 0)
+	}
+	if rawType.Chan == nil {
+		rawType.Chan = make(map[string]string, 0)
+	}
+	*o = Type(rawType)
+	return nil
+}
+
+func (o Type) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (o *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -32,3 +32,8 @@ types:
       BinaryMap:
         fields:
           map: map<binary,binary>
+      Type:
+        docs: A type using go keywords
+        fields:
+          type: list<string>
+          chan: map<string, string>


### PR DESCRIPTION
Service generation is broken in the same way, working on a fix

cc @MatthewMaclean

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/53)
<!-- Reviewable:end -->
