### PR TITLE
serverwriter: Correctly escape go keywords

### DIFF
--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -360,7 +360,7 @@ func getHandleMethodBody(serviceDefinition spec.ServiceDefinition, endpoint spec
 	}
 
 	for _, arg := range endpoint.Args {
-		varsToPassIntoImpl = append(varsToPassIntoImpl, expression.VariableVal(arg.ArgName))
+		varsToPassIntoImpl = append(varsToPassIntoImpl, expression.VariableVal(transforms.SafeName(string(arg.ArgName))))
 	}
 
 	returnStatements, err := getReturnStatements(serviceDefinition, endpoint, varsToPassIntoImpl, info)
@@ -444,7 +444,7 @@ func getBodyParamStatements(bodyParam *visitors.ArgumentDefinitionBodyParam, inf
 		return nil, nil
 	}
 	var body []astgen.ASTStmt
-	argName := string(bodyParam.ArgumentDefinition.ArgName)
+	argName := transforms.SafeName(string(bodyParam.ArgumentDefinition.ArgName))
 	typer, err := visitors.NewConjureTypeProviderTyper(bodyParam.ArgumentDefinition.Type, info)
 	if err != nil {
 		typJSON, _ := bodyParam.ArgumentDefinition.Type.MarshalJSON()
@@ -609,7 +609,7 @@ func getPathParamStatements(pathParams []visitors.ArgumentDefinitionPathParam, i
 
 		var strVar expression.VariableVal
 		if isString {
-			strVar = expression.VariableVal(arg.ArgName)
+			strVar = expression.VariableVal(transforms.SafeName(string(arg.ArgName)))
 		} else {
 			strVar = expression.VariableVal(arg.ArgName + "Str")
 		}
@@ -646,7 +646,8 @@ func getPathParamStatements(pathParams []visitors.ArgumentDefinitionPathParam, i
 
 		// type-specific unmarshal behavior
 		if !isString {
-			paramStmts, err := visitors.ParseStringParam(arg.ArgName, arg.Type, strVar, info)
+			argName := spec.ArgumentName(transforms.SafeName(string(arg.ArgName)))
+			paramStmts, err := visitors.ParseStringParam(argName, arg.Type, strVar, info)
 			if err != nil {
 				return nil, err
 			}
@@ -676,7 +677,8 @@ func getHeaderParamStatements(headerParams []visitors.ArgumentDefinitionHeaderPa
 		}
 		// type-specific unmarshal behavior
 		// TODO (bmoylan): lists are unimplemented right now, but we _could_ iterate through the raw map and pull them out.
-		paramStmts, err := visitors.ParseStringParam(arg.ArgName, arg.Type, getHeader, info)
+		argName := spec.ArgumentName(transforms.SafeName(string(arg.ArgName)))
+		paramStmts, err := visitors.ParseStringParam(argName, arg.Type, getHeader, info)
 		if err != nil {
 			return nil, err
 		}
@@ -711,7 +713,8 @@ func getQueryParamStatements(queryParams []visitors.ArgumentDefinitionQueryParam
 		ifErrNotNilReturnErrStatement("err", nil)
 		// type-specific unmarshal behavior
 		// TODO(bmoylan): lists are unimplemented right now, but we _could_ iterate through the raw map and pull them out.
-		paramStmts, err := visitors.ParseStringParam(arg.ArgName, arg.Type, getQuery, info)
+		argName := spec.ArgumentName(transforms.SafeName(string(arg.ArgName)))
+		paramStmts, err := visitors.ParseStringParam(argName, arg.Type, getQuery, info)
 		if err != nil {
 			return nil, err
 		}

--- a/godel/config/godel.yml
+++ b/godel/config/godel.yml
@@ -22,3 +22,4 @@ exclude:
     - "conjure-go-verifier/conjure"
     - "integration_test/testgenerated/errors/api"
     - "integration_test/testgenerated/objects/api"
+    - "integration_test/testgenerated/server/api"

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -23,6 +23,8 @@ type TestServiceClient interface {
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
 	PutBinary(ctx context.Context, myBytesArg func() io.ReadCloser) error
+	// An endpoint that uses go keywords
+	Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error
 }
 
 type testServiceClient struct {
@@ -169,6 +171,24 @@ func (c *testServiceClient) PutBinary(ctx context.Context, myBytesArg func() io.
 	return nil
 }
 
+func (c *testServiceClient) Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("Chan"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
+	requestParams = append(requestParams, httpclient.WithPathf("/chan/%s", url.PathEscape(fmt.Sprint(varArg))))
+	requestParams = append(requestParams, httpclient.WithJSONRequest(importArg))
+	requestParams = append(requestParams, httpclient.WithHeader("X-My-Header2", fmt.Sprint(returnArg)))
+	queryParams := make(url.Values)
+	queryParams.Set("type", fmt.Sprint(typeArg))
+	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
+	resp, err := c.client.Do(ctx, requestParams...)
+	if err != nil {
+		return err
+	}
+	_ = resp
+	return nil
+}
+
 type TestServiceClientWithAuth interface {
 	Echo(ctx context.Context) error
 	GetPathParam(ctx context.Context, myPathParamArg string) error
@@ -178,6 +198,8 @@ type TestServiceClientWithAuth interface {
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
 	PutBinary(ctx context.Context, myBytesArg func() io.ReadCloser) error
+	// An endpoint that uses go keywords
+	Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error
 }
 
 func NewTestServiceClientWithAuth(client TestServiceClient, authHeader bearertoken.Token, cookieToken bearertoken.Token) TestServiceClientWithAuth {
@@ -220,4 +242,8 @@ func (c *testServiceClientWithAuth) PostBinary(ctx context.Context, myBytesArg f
 
 func (c *testServiceClientWithAuth) PutBinary(ctx context.Context, myBytesArg func() io.ReadCloser) error {
 	return c.client.PutBinary(ctx, myBytesArg)
+}
+
+func (c *testServiceClientWithAuth) Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error {
+	return c.client.Chan(ctx, varArg, importArg, typeArg, returnArg)
 }

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -76,3 +76,16 @@ services:
         http: PUT /binary
         args:
           myBytes: binary
+      chan:
+        docs: An endpoint that uses go keywords
+        http: POST /chan/{var}
+        args:
+          var: string
+          import: map<string, string>
+          type:
+            param-type: query
+            type: string
+          return:
+            param-type: header
+            param-id: X-My-Header2
+            type: safelong


### PR DESCRIPTION
Similar to #53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/54)
<!-- Reviewable:end -->
