### PR TITLE
Fix: add String() function for text alias types

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,7 +170,7 @@
   version = "v4.0.0"
 
 [[projects]]
-  digest = "1:ee5657d56e2c8a9f4cb15a219262585d8ff33bc778cd9e845dd008a34962d6cd"
+  digest = "1:d6a4e4b0c5bdcebdd8532af5916195853249ea10b0c6c5858fbc48960188d5a2"
   name = "github.com/palantir/pkg"
   packages = [
     "bearertoken",
@@ -194,8 +194,8 @@
     "uuid/internal/uuid",
   ]
   pruneopts = "UT"
-  revision = "7fd8d6e85a713f1ec5376c81b97c7ed1033c9816"
-  version = "0.10.0"
+  revision = "3c3292ada62a06084577c127e16e99b7a14675b5"
+  version = "0.10.5"
 
 [[projects]]
   digest = "1:89b7c2365c6b481a9e1c83a203c817d117376f48330811a977d84ec198281c8b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
 
 [[constraint]]
   name = "github.com/palantir/pkg"
-  version = ">=0.10.0"
+  version = ">=0.10.5"
 
 [prune]
   go-tests = true

--- a/changelog/@unreleased/pr-70.v2.yml
+++ b/changelog/@unreleased/pr-70.v2.yml
@@ -1,0 +1,12 @@
+type: fix
+fix:
+  description: |-
+    Add String() function for text alias types
+
+    Make it so that any alias type that defines a MarshalText function
+    also defines a String function that delegates to the String() function
+    of the type being aliased.
+
+    Fixes #68
+  links:
+  - https://github.com/palantir/conjure-go/pull/70

--- a/conjure-go-verifier/conjure/verification/types/aliases.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/aliases.conjure.go
@@ -572,6 +572,10 @@ func (a *ReferenceAliasExample) UnmarshalYAML(unmarshal func(interface{}) error)
 type ListBinaryAliasExample [][]byte
 type UuidAliasExample uuid.UUID
 
+func (a UuidAliasExample) String() string {
+	return uuid.UUID(a).String()
+}
+
 func (a UuidAliasExample) MarshalText() ([]byte, error) {
 	return uuid.UUID(a).MarshalText()
 }
@@ -733,6 +737,10 @@ func (a *OptionalDoubleAliasExample) UnmarshalYAML(unmarshal func(interface{}) e
 
 type RidAliasExample rid.ResourceIdentifier
 
+func (a RidAliasExample) String() string {
+	return rid.ResourceIdentifier(a).String()
+}
+
 func (a RidAliasExample) MarshalText() ([]byte, error) {
 	return rid.ResourceIdentifier(a).MarshalText()
 }
@@ -862,6 +870,10 @@ func (a *ListSafeLongAliasExample) UnmarshalYAML(unmarshal func(interface{}) err
 }
 
 type DateTimeAliasExample datetime.DateTime
+
+func (a DateTimeAliasExample) String() string {
+	return datetime.DateTime(a).String()
+}
 
 func (a DateTimeAliasExample) MarshalText() ([]byte, error) {
 	return datetime.DateTime(a).MarshalText()
@@ -1125,6 +1137,10 @@ func (a *MapEnumExampleAlias) UnmarshalYAML(unmarshal func(interface{}) error) e
 
 type ListDoubleAliasExample []float64
 type BearerTokenAliasExample bearertoken.Token
+
+func (a BearerTokenAliasExample) String() string {
+	return bearertoken.Token(a).String()
+}
 
 func (a BearerTokenAliasExample) MarshalText() ([]byte, error) {
 	return bearertoken.Token(a).MarshalText()

--- a/conjure/encoding_methods.go
+++ b/conjure/encoding_methods.go
@@ -29,6 +29,20 @@ const (
 	dataVarName = "data"
 )
 
+func newStringMethod(receiverName, receiverType string, body ...astgen.ASTStmt) *decl.Method {
+	return &decl.Method{
+		ReceiverName: receiverName,
+		ReceiverType: expression.Type(receiverType),
+		Function: decl.Function{
+			Name: "String",
+			FuncType: expression.FuncType{
+				ReturnTypes: []expression.Type{expression.StringType},
+			},
+			Body: body,
+		},
+	}
+}
+
 func newMarshalTextMethod(receiverName, receiverType string, body ...astgen.ASTStmt) *decl.Method {
 	return &decl.Method{
 		ReceiverName: receiverName,

--- a/integration_test/testgenerated/client/api/aliases.conjure.go
+++ b/integration_test/testgenerated/client/api/aliases.conjure.go
@@ -2,4 +2,45 @@
 
 package api
 
+import (
+	"github.com/palantir/pkg/rid"
+	"github.com/palantir/pkg/safejson"
+	"github.com/palantir/pkg/safeyaml"
+)
+
+type RidAlias rid.ResourceIdentifier
+
+func (a RidAlias) String() string {
+	return rid.ResourceIdentifier(a).String()
+}
+
+func (a RidAlias) MarshalText() ([]byte, error) {
+	return rid.ResourceIdentifier(a).MarshalText()
+}
+
+func (a *RidAlias) UnmarshalText(data []byte) error {
+	var rawRidAlias rid.ResourceIdentifier
+	if err := rawRidAlias.UnmarshalText(data); err != nil {
+		return err
+	}
+	*a = RidAlias(rawRidAlias)
+	return nil
+}
+
+func (a RidAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *RidAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type StringAlias string

--- a/integration_test/testgenerated/client/api/services.conjure.go
+++ b/integration_test/testgenerated/client/api/services.conjure.go
@@ -9,12 +9,15 @@ import (
 	"net/url"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
+	"github.com/palantir/pkg/rid"
 )
 
 type TestServiceClient interface {
 	Echo(ctx context.Context) error
 	PathParam(ctx context.Context, paramArg string) error
 	PathParamAlias(ctx context.Context, paramArg StringAlias) error
+	PathParamRid(ctx context.Context, paramArg rid.ResourceIdentifier) error
+	PathParamRidAlias(ctx context.Context, paramArg RidAlias) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	Binary(ctx context.Context) (io.ReadCloser, error)
 }
@@ -58,6 +61,32 @@ func (c *testServiceClient) PathParamAlias(ctx context.Context, paramArg StringA
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamAlias"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	resp, err := c.client.Do(ctx, requestParams...)
+	if err != nil {
+		return err
+	}
+	_ = resp
+	return nil
+}
+
+func (c *testServiceClient) PathParamRid(ctx context.Context, paramArg rid.ResourceIdentifier) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamRid"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/rid/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	resp, err := c.client.Do(ctx, requestParams...)
+	if err != nil {
+		return err
+	}
+	_ = resp
+	return nil
+}
+
+func (c *testServiceClient) PathParamRidAlias(ctx context.Context, paramArg RidAlias) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamRidAlias"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/rid/alias/%s", url.PathEscape(fmt.Sprint(paramArg))))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
 		return err

--- a/integration_test/testgenerated/client/client-service.yml
+++ b/integration_test/testgenerated/client/client-service.yml
@@ -2,6 +2,8 @@ types:
   definitions:
     default-package: api
     objects:
+      RidAlias:
+        alias: rid
       StringAlias:
         alias: string
       CustomObject:
@@ -22,6 +24,14 @@ services:
         http: GET /path/alias/{param}
         args:
           param: StringAlias
+      pathParamRid:
+        http: GET /path/rid/{param}
+        args:
+          param: rid
+      pathParamRidAlias:
+        http: GET /path/rid/alias/{param}
+        args:
+          param: RidAlias
       bytes:
         http: GET /bytes
         returns: CustomObject

--- a/integration_test/testgenerated/objects/api/aliases.conjure.go
+++ b/integration_test/testgenerated/objects/api/aliases.conjure.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"github.com/palantir/pkg/rid"
 	"github.com/palantir/pkg/safejson"
 	"github.com/palantir/pkg/safeyaml"
 	"github.com/palantir/pkg/uuid"
@@ -76,6 +77,10 @@ func (a *OptionalUuidAlias) UnmarshalYAML(unmarshal func(interface{}) error) err
 
 type UuidAlias uuid.UUID
 
+func (a UuidAlias) String() string {
+	return uuid.UUID(a).String()
+}
+
 func (a UuidAlias) MarshalText() ([]byte, error) {
 	return uuid.UUID(a).MarshalText()
 }
@@ -98,6 +103,41 @@ func (a UuidAlias) MarshalYAML() (interface{}, error) {
 }
 
 func (a *UuidAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
+type RidAlias rid.ResourceIdentifier
+
+func (a RidAlias) String() string {
+	return rid.ResourceIdentifier(a).String()
+}
+
+func (a RidAlias) MarshalText() ([]byte, error) {
+	return rid.ResourceIdentifier(a).MarshalText()
+}
+
+func (a *RidAlias) UnmarshalText(data []byte) error {
+	var rawRidAlias rid.ResourceIdentifier
+	if err := rawRidAlias.UnmarshalText(data); err != nil {
+		return err
+	}
+	*a = RidAlias(rawRidAlias)
+	return nil
+}
+
+func (a RidAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *RidAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
 	if err != nil {
 		return err

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -23,6 +23,8 @@ types:
           uid: uuid
       OptionalUuidAlias:
         alias: optional<uuid>
+      RidAlias:
+        alias: rid
       UuidAlias:
         alias: uuid
       UuidAlias2:

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -16,9 +16,11 @@ package objects_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"testing"
 
+	"github.com/palantir/pkg/rid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -88,6 +90,14 @@ func TestStrOptionalNonNil(t *testing.T) {
 	bytes, err = union.MarshalJSON()
 	require.NoError(t, err)
 	assert.Equal(t, `{"type":"strOptional","strOptional":"hello"}`, string(bytes))
+}
+
+func TestRidAliasString(t *testing.T) {
+	parsedRID, err := rid.ParseRID("ri.a1p2p3.south-west.data-set.my-hello_WORLD-123")
+	require.NoError(t, err)
+
+	ridAlias := api.RidAlias(parsedRID)
+	assert.Equal(t, "ri.a1p2p3.south-west.data-set.my-hello_WORLD-123", fmt.Sprint(ridAlias))
 }
 
 func TestMarshal(t *testing.T) {

--- a/vendor/github.com/palantir/pkg/bearertoken/bearertoken.go
+++ b/vendor/github.com/palantir/pkg/bearertoken/bearertoken.go
@@ -8,6 +8,10 @@ package bearertoken
 // Authorization or Cookie header for authentication purposes.
 type Token string
 
+func (t Token) String() string {
+	return string(t)
+}
+
 func (t Token) MarshalText() ([]byte, error) {
 	return []byte(t), nil
 }

--- a/vendor/github.com/palantir/pkg/binary/binary.go
+++ b/vendor/github.com/palantir/pkg/binary/binary.go
@@ -25,6 +25,10 @@ func (b Binary) Bytes() ([]byte, error) {
 	return b64.DecodeString(string(b))
 }
 
+func (b Binary) String() string {
+	return string(b)
+}
+
 func (b Binary) MarshalText() (text []byte, err error) {
 	// Verify that data is base64-encoded
 	if _, err := b.Bytes(); err != nil {

--- a/vendor/github.com/palantir/pkg/metrics/context.go
+++ b/vendor/github.com/palantir/pkg/metrics/context.go
@@ -40,19 +40,20 @@ func FromContext(ctx context.Context) Registry {
 	}
 }
 
-// AddTags adds the provided tags to the provided context. If the provided context already has tag storage, the new tags
-// are appended to the storage in the existing context (which mutates the content of the context) and returns the same
-// context. If the provided context does not store any tags, this call creates and returns a new context that has tag
-// storage and stores the provided tags. If the provided context has any tags already set on it, the provided tags are
-// appended to them. This function does not perform any de-duplication (that is, if a tag in the provided tags has the
-// same key as an existing one, it will still be appended). Note that tags are shared
+// AddTags adds the provided tags to the provided context. If no tags are provided, the context is returned unchanged.
+// Otherwise, a new context is returned with the new tags appended to any tags stored on the parent context.
+// This function does not perform any de-duplication (that is, if a tag in the provided tags has the
+// same key as an existing one, it will still be appended).
 func AddTags(ctx context.Context, tags ...Tag) context.Context {
-	if tagsContainer, ok := ctx.Value(tagsKey).(*tagsContainer); ok && tagsContainer != nil {
-		tagsContainer.Tags = append(tagsContainer.Tags, tags...)
+	if len(tags) == 0 {
 		return ctx
 	}
+	container, ok := ctx.Value(tagsKey).(*tagsContainer)
+	if !ok || container == nil {
+		container = &tagsContainer{}
+	}
 	return context.WithValue(ctx, tagsKey, &tagsContainer{
-		Tags: tags,
+		Tags: append(container.Tags, tags...),
 	})
 }
 

--- a/vendor/github.com/palantir/pkg/metrics/tag.go
+++ b/vendor/github.com/palantir/pkg/metrics/tag.go
@@ -76,6 +76,18 @@ func MustNewTag(k, v string) Tag {
 	return t
 }
 
+// NewTagWithFallbackValue returns the result of calling NewTag, and if that fails, calls MustNewTag with a fallback
+// value. This function is useful when the value is provided as a runtime input and the desired behavior is to fall back
+// to using a known valid value (e.g., "unknown") when the value is invalid. Note: because MustNewTag will panic if it
+// fails, both the key and fallback value must be known valid.
+func NewTagWithFallbackValue(k, v, fallback string) Tag {
+	tag, err := NewTag(k, v)
+	if err != nil {
+		return MustNewTag(k, fallback)
+	}
+	return tag
+}
+
 // NewTag returns a tag that uses the provided key and value. The returned tag is normalized to conform with the DataDog
 // tag specification. The key and value must be non-empty and the key must begin with a letter. The string form of the
 // returned tag is "normalized(k):normalized(v)".


### PR DESCRIPTION
## Before this PR
`conjure-go` performs "PLAIN" serialization of types (used in scenarios like header and query parameters) by using `fmt.Sprint`. The types for `datetime` and `rid` implement `String()`, so this works fine.

However, types that are aliases of these types do not generate code for `String()`, so they do not use the custom string representation, and thus break.

## After this PR
==COMMIT_MSG==
Make it so that any alias type that defines a MarshalText function
also defines a String function that delegates to MarshalText.

Fixes #68
==COMMIT_MSG==

## Possible downsides?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/70)
<!-- Reviewable:end -->
