### PR TITLE
Use named type for generating server or client

### DIFF
--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -214,8 +214,7 @@ func getResourceFunction(endpointDefinition spec.EndpointDefinition) string {
 
 func AstForServerInterface(serviceDefinition spec.ServiceDefinition, info types.PkgInfo) ([]astgen.ASTDecl, error) {
 	serviceName := serviceDefinition.ServiceName.Name
-	isClient := false
-	interfaceAST, _, err := serviceInterfaceAST(serviceDefinition, info, false, isClient)
+	interfaceAST, _, err := serverServiceInterfaceAST(serviceDefinition, info, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate interface for service %q", serviceName)
 	}


### PR DESCRIPTION
Separating the functions makes more semantic sense given that, as
currently used, all callers use a hard-coded constant when calling
the function. If the caller always knows the "mode" of the function
being called at compile-time, it's good signal that these should just
be separate functions (which also reduces number of parameters and
makes the behavior clearer based on the name).

Only refactors internal private functions.

==NO_CHANGELOG==

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/77)
<!-- Reviewable:end -->
