### PR TITLE
Fix: ensure that imports for generated server code are correct

### DIFF
--- a/changelog/@unreleased/pr-107.v2.yml
+++ b/changelog/@unreleased/pr-107.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Ensure that imports for endpoint definitions are processed and
+    added before generating server code so that import paths for
+    endpoint objects are correct.
+  links:
+  - https://github.com/palantir/conjure-go/pull/107

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -220,39 +220,39 @@ func (c *outputFileCollector) VisitError(errorDefinition spec.ErrorDefinition) e
 }
 
 func (c *outputFileCollector) VisitService(serviceDefinition spec.ServiceDefinition) error {
-	info := c.services.Info
-	if err := addImportsToPkgInfoFromServiceDefinitionEndpoints(&info, serviceDefinition); err != nil {
+	servicesInfo := c.services.Info
+	if err := addImportsToPkgInfoFromServiceDefinitionEndpoints(&servicesInfo, serviceDefinition); err != nil {
 		return err
 	}
 
-	declers, imports, err := astForService(serviceDefinition, info)
+	declers, imports, err := astForService(serviceDefinition, servicesInfo)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
 	}
-	info.AddImports(imports.Sorted()...)
+	servicesInfo.AddImports(imports.Sorted()...)
 	c.services.Decls = append(c.services.Decls, declers...)
 
 	// Generate server code if GenerateServer configuration is enabled
 	if c.cfg.GenerateServer {
-		info := c.servers.Info
-		if err := addImportsToPkgInfoFromServiceDefinitionEndpoints(&info, serviceDefinition); err != nil {
+		serversInfo := c.servers.Info
+		if err := addImportsToPkgInfoFromServiceDefinitionEndpoints(&serversInfo, serviceDefinition); err != nil {
 			return err
 		}
 
-		serverInterfaces, err := AstForServerInterface(serviceDefinition, info)
+		serverInterfaces, err := AstForServerInterface(serviceDefinition, serversInfo)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
 		}
 		c.servers.Decls = append(c.servers.Decls, serverInterfaces...)
 
-		routeReg, err := ASTForServerRouteRegistration(serviceDefinition, info)
+		routeReg, err := ASTForServerRouteRegistration(serviceDefinition, serversInfo)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
 		}
 		c.servers.Decls = append(c.servers.Decls, routeReg...)
 		c.servers.Info.AddImports(imports.Sorted()...)
 
-		handlers, err := AstForServerFunctionHandler(serviceDefinition, info)
+		handlers, err := AstForServerFunctionHandler(serviceDefinition, serversInfo)
 		if err != nil {
 			return errors.Wrapf(err, "failed to generate AST for service %s", serviceDefinition.ServiceName.Name)
 		}


### PR DESCRIPTION
## Before this PR
Imports from endpoint definitions were added before generating service client code, but not service server code. In some instances, this would cause the import for an endpoint object to be resolved to a different local package instead of to the generated package.

## After this PR
==COMMIT_MSG==
Ensure that imports for endpoint definitions are processed and
added before generating server code so that import paths for
endpoint objects are correct.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/107)
<!-- Reviewable:end -->
