### PR TITLE
Improvement: Generated errors implement ParamStorer interface

### DIFF
--- a/changelog/@unreleased/pr-114.v2.yml
+++ b/changelog/@unreleased/pr-114.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Generated error types now implement the wparams.ParamStorer interface.
+    This ensures any downstream consumers of the error (e.g., witchcraft-go-logging)
+    will automatically do the right thing with the params.
+  links:
+  - https://github.com/palantir/conjure-go/pull/114

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2180,6 +2180,16 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "unsafeArgA": e.UnsafeArgA}
 }
 
+// SafeParams returns a set of named safe parameters detailing this particular error instance.
+func (e *MyNotFound) SafeParams() map[string]interface{} {
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "errorInstanceId": e.errorInstanceID}
+}
+
+// UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.
+func (e *MyNotFound) UnsafeParams() map[string]interface{} {
+	return map[string]interface{}{"unsafeArgA": e.UnsafeArgA}
+}
+
 func (e MyNotFound) MarshalJSON() ([]byte, error) {
 	parameters, err := safejson.Marshal(e.myNotFound)
 	if err != nil {

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -33,6 +33,7 @@ import (
 const (
 	errorReceiverName    = "e"
 	errorInstanceIDField = "errorInstanceID"
+	errorInstanceIDParam = "errorInstanceId"
 )
 
 const (
@@ -359,7 +360,7 @@ func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.P
 		))
 	}
 	keyValues = append(keyValues, expression.NewKeyValue(
-		fmt.Sprintf("%q", errorInstanceIDField),
+		fmt.Sprintf("%q", errorInstanceIDParam),
 		expression.NewSelector(
 			expression.VariableVal(errorReceiverName),
 			errorInstanceIDField,

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -348,7 +348,7 @@ func astErrorParametersMethod(errorDefinition spec.ErrorDefinition, info types.P
 //  	return map[string]interface{}{"safeArgA": e.safeArgA, "safeArgB": e.safeArgB}
 //  }
 func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
-	var keyValues []astgen.ASTExpr
+	keyValues := make([]astgen.ASTExpr, 0, len(errorDefinition.SafeArgs)+1)
 	for _, fieldDefinition := range errorDefinition.SafeArgs {
 		keyValues = append(keyValues, expression.NewKeyValue(
 			fmt.Sprintf("%q", fieldDefinition.FieldName),
@@ -358,6 +358,13 @@ func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.P
 			),
 		))
 	}
+	keyValues = append(keyValues, expression.NewKeyValue(
+		fmt.Sprintf("%q", errorInstanceIDField),
+		expression.NewSelector(
+			expression.VariableVal(errorReceiverName),
+			errorInstanceIDField,
+		),
+	))
 	return &decl.Method{
 		Function: decl.Function{
 			Name: "SafeParams",

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -137,6 +137,8 @@ func astForError(errorDefinition spec.ErrorDefinition, info types.PkgInfo) ([]as
 		astErrorNameMethod,
 		astErrorInstanceIDMethod,
 		astErrorParametersMethod,
+		astErrorSafeParamsMethod,
+		astErrorUnsafeParamsMethod,
 		astErrorMarshalJSON,
 		astErrorUnmarshalJSON,
 	} {
@@ -334,6 +336,84 @@ func astErrorParametersMethod(errorDefinition spec.ErrorDefinition, info types.P
 				),
 			},
 			Comment: "Parameters returns a set of named parameters detailing this particular error instance.",
+		},
+		ReceiverName: errorReceiverName,
+		ReceiverType: expression.Type(errorDefinition.ErrorName.Name).Pointer(),
+	}
+}
+
+// astErrorSafeParamsMethod generates SafeParams function for an error, for example:
+//
+//  func (e *MyNotFound) SafeParams() map[string]interface{} {
+//  	return map[string]interface{}{"safeArgA": e.safeArgA, "safeArgB": e.safeArgB}
+//  }
+func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
+	var keyValues []astgen.ASTExpr
+	for _, fieldDefinition := range errorDefinition.SafeArgs {
+		keyValues = append(keyValues, expression.NewKeyValue(
+			fmt.Sprintf("%q", fieldDefinition.FieldName),
+			expression.NewSelector(
+				expression.VariableVal(errorReceiverName),
+				transforms.Export(string(fieldDefinition.FieldName)),
+			),
+		))
+	}
+	return &decl.Method{
+		Function: decl.Function{
+			Name: "SafeParams",
+			FuncType: expression.FuncType{
+				ReturnTypes: []expression.Type{
+					"map[string]interface{}",
+				},
+			},
+			Body: []astgen.ASTStmt{
+				statement.NewReturn(
+					expression.NewCompositeLit(
+						expression.Type("map[string]interface{}"),
+						keyValues...,
+					),
+				),
+			},
+			Comment: "SafeParams returns a set of named safe parameters detailing this particular error instance.",
+		},
+		ReceiverName: errorReceiverName,
+		ReceiverType: expression.Type(errorDefinition.ErrorName.Name).Pointer(),
+	}
+}
+
+// astErrorUnsafeParamsMethod generates UnsafeParams function for an error, for example:
+//
+//  func (e *MyNotFound) UnsafeParams() map[string]interface{} {
+//  	return map[string]interface{}{"unsafeArgA": e.unsafeArgA, "unsafeArgB": e.unsafeArgB}
+//  }
+func astErrorUnsafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
+	var keyValues []astgen.ASTExpr
+	for _, fieldDefinition := range errorDefinition.UnsafeArgs {
+		keyValues = append(keyValues, expression.NewKeyValue(
+			fmt.Sprintf("%q", fieldDefinition.FieldName),
+			expression.NewSelector(
+				expression.VariableVal(errorReceiverName),
+				transforms.Export(string(fieldDefinition.FieldName)),
+			),
+		))
+	}
+	return &decl.Method{
+		Function: decl.Function{
+			Name: "UnsafeParams",
+			FuncType: expression.FuncType{
+				ReturnTypes: []expression.Type{
+					"map[string]interface{}",
+				},
+			},
+			Body: []astgen.ASTStmt{
+				statement.NewReturn(
+					expression.NewCompositeLit(
+						expression.Type("map[string]interface{}"),
+						keyValues...,
+					),
+				),
+			},
+			Comment: "UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.",
 		},
 		ReceiverName: errorReceiverName,
 		ReceiverType: expression.Type(errorDefinition.ErrorName.Name).Pointer(),

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -346,7 +346,7 @@ func astErrorParametersMethod(errorDefinition spec.ErrorDefinition, info types.P
 // astErrorSafeParamsMethod generates SafeParams function for an error, for example:
 //
 //  func (e *MyNotFound) SafeParams() map[string]interface{} {
-//  	return map[string]interface{}{"safeArgA": e.safeArgA, "safeArgB": e.safeArgB}
+//  	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB}
 //  }
 func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
 	keyValues := make([]astgen.ASTExpr, 0, len(errorDefinition.SafeArgs)+1)
@@ -392,7 +392,7 @@ func astErrorSafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.P
 // astErrorUnsafeParamsMethod generates UnsafeParams function for an error, for example:
 //
 //  func (e *MyNotFound) UnsafeParams() map[string]interface{} {
-//  	return map[string]interface{}{"unsafeArgA": e.unsafeArgA, "unsafeArgB": e.unsafeArgB}
+//  	return map[string]interface{}{"unsafeArgA": e.UnsafeArgA}
 //  }
 func astErrorUnsafeParamsMethod(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
 	var keyValues []astgen.ASTExpr

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/palantir/pkg/uuid v1.0.1
 	github.com/palantir/witchcraft-go-error v1.2.0
 	github.com/palantir/witchcraft-go-logging v1.5.0
+	github.com/palantir/witchcraft-go-params v1.1.0
 	github.com/palantir/witchcraft-go-server v1.13.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -99,7 +99,7 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance.
 func (e *MyNotFound) SafeParams() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceID": e.errorInstanceID}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceId": e.errorInstanceID}
 }
 
 // UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -99,7 +99,7 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance.
 func (e *MyNotFound) SafeParams() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceID": e.errorInstanceID}
 }
 
 // UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -97,6 +97,16 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
 }
 
+// SafeParams returns a set of named safe parameters detailing this particular error instance.
+func (e *MyNotFound) SafeParams() map[string]interface{} {
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type}
+}
+
+// UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.
+func (e *MyNotFound) UnsafeParams() map[string]interface{} {
+	return map[string]interface{}{"unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
+}
+
 func (e MyNotFound) MarshalJSON() ([]byte, error) {
 	parameters, err := safejson.Marshal(e.myNotFound)
 	if err != nil {

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -88,7 +88,7 @@ func TestError_UnmarshalJSON(t *testing.T) {
 
 func TestError_SafeParams(t *testing.T) {
 	safeParams := testError.SafeParams()
-	for _, key := range []string{"safeArgA", "safeArgB", "type", "errorInstanceID"} {
+	for _, key := range []string{"safeArgA", "safeArgB", "type", "errorInstanceId"} {
 		assert.Contains(t, safeParams, key)
 	}
 }

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -17,6 +17,7 @@ package errors_test
 import (
 	"encoding/json"
 	"fmt"
+	wparams "github.com/palantir/witchcraft-go-params"
 	"testing"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-contract/errors"
@@ -28,6 +29,7 @@ import (
 var _ errors.Error = &api.MyNotFound{}
 var _ json.Marshaler = &api.MyNotFound{}
 var _ json.Unmarshaler = &api.MyNotFound{}
+var _ wparams.ParamStorer = &api.MyNotFound{}
 
 var testError = api.NewMyNotFound(
 	api.Basic{
@@ -86,7 +88,7 @@ func TestError_UnmarshalJSON(t *testing.T) {
 
 func TestError_SafeParams(t *testing.T) {
 	safeParams := testError.SafeParams()
-	for _, key := range []string{"safeArgA", "safeArgB", "type"} {
+	for _, key := range []string{"safeArgA", "safeArgB", "type", "errorInstanceID"} {
 		assert.Contains(t, safeParams, key)
 	}
 }

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -83,3 +83,17 @@ func TestError_UnmarshalJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, testError, &myNotFound)
 }
+
+func TestError_SafeParams(t *testing.T) {
+	safeParams := testError.SafeParams()
+	for _, key := range []string{"safeArgA", "safeArgB", "type"} {
+		assert.Contains(t, safeParams, key)
+	}
+}
+
+func TestError_UnsafeParams(t *testing.T) {
+	unsafeParams := testError.UnsafeParams()
+	for _, key := range []string{"unsafeArgA", "unsafeArgB"} {
+		assert.Contains(t, unsafeParams, key)
+	}
+}

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -17,10 +17,10 @@ package errors_test
 import (
 	"encoding/json"
 	"fmt"
-	wparams "github.com/palantir/witchcraft-go-params"
 	"testing"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-contract/errors"
+	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/palantir/conjure-go/v4/integration_test/testgenerated/errors/api"


### PR DESCRIPTION
## Before this PR
There was no way to know which param fields in the generated error types were safe vs unsafe.

## After this PR
==COMMIT_MSG==
Generated error types now implement the [`wparams.ParamStorer`](https://github.com/palantir/witchcraft-go-params/blob/develop/paramstorer.go) interface. This ensures any downstream consumers of the error (e.g., witchcraft-go-logging) will automatically do the right thing with the params.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/114)
<!-- Reviewable:end -->
