### PR TITLE
Break: Generated servers emit conjure errors

### DIFF
--- a/changelog/@unreleased/pr-117.v2.yml
+++ b/changelog/@unreleased/pr-117.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: |-
+    Generated servers emit conjure errors, allowing them to be deserialized by conjure-go-runtime clients
+  links:
+  - https://github.com/palantir/conjure-go/pull/117

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -547,7 +547,7 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 	} else if cookieAuth != nil {
 		//	authCookie, err := req.Cookie("P_TOKEN")
 		//	if err != nil {
-		//		return errors.NewPermissionDenied(map[string]interface{"stacktrace": err.Error()})
+		//		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 		//	}
 		//	cookieToken := bearertoken.Token(authCookie.Value)
 		body = append(body,

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -518,7 +518,7 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 		body = append(body,
 			//	authHeader, err := rest.ParseBearerTokenHeader(req)
 			//	if err != nil {
-			//		return errors.NewPermissionDenied()
+			//		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 			//	}
 			&statement.Assignment{
 				LHS: []astgen.ASTExpr{

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -484,8 +484,8 @@ func getBodyParamStatements(bodyParam *visitors.ArgumentDefinitionBodyParam, inf
 			Body: []astgen.ASTStmt{
 				&statement.Return{
 					Values: []astgen.ASTExpr{
-						getNewWrappedError(expression.VariableVal(errorName),
-							getNewConjureError("NewInvalidArgument", nil)),
+						getNewWrappedError(getNewConjureError("NewInvalidArgument", nil),
+							expression.VariableVal(errorName)),
 					}},
 			},
 		})
@@ -502,8 +502,8 @@ func getNewConjureError(errorType string, paramsVal astgen.ASTExpr) astgen.ASTEx
 }
 
 // errors.NewWrappedError(err, conjureErr)
-func getNewWrappedError(err, conjureErr astgen.ASTExpr) astgen.ASTExpr {
-	return expression.NewCallFunction(errorsImportPackage, "NewWrappedError", err, conjureErr)
+func getNewWrappedError(conjureErr, err astgen.ASTExpr) astgen.ASTExpr {
+	return expression.NewCallFunction(errorsImportPackage, "NewWrappedError", conjureErr, err)
 }
 
 func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStmt, error) {
@@ -533,8 +533,8 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 				Body: []astgen.ASTStmt{
 					&statement.Return{
 						Values: []astgen.ASTExpr{
-							getNewWrappedError(expression.VariableVal(errorName),
-								getNewConjureError("NewPermissionDenied", nil)),
+							getNewWrappedError(getNewConjureError("NewPermissionDenied", nil),
+								expression.VariableVal(errorName)),
 						}},
 				},
 			},
@@ -564,8 +564,8 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 				Body: []astgen.ASTStmt{
 					&statement.Return{
 						Values: []astgen.ASTExpr{
-							getNewWrappedError(expression.VariableVal(errorName),
-								getNewConjureError("NewPermissionDenied", nil)),
+							getNewWrappedError(getNewConjureError("NewPermissionDenied", nil),
+								expression.VariableVal(errorName)),
 						}},
 				},
 			},

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -607,7 +607,7 @@ func getPathParamStatements(pathParams []visitors.ArgumentDefinitionPathParam, i
 		Body: []astgen.ASTStmt{
 			&statement.Return{Values: []astgen.ASTExpr{
 				werrorexpressions.CreateWrapWErrorExpression(
-					getNewConjureError("NewNotFound", nil), "path params not found on request: ensure this endpoint is registered with wrouter", nil),
+					getNewConjureError("NewInternal", nil), "path params not found on request: ensure this endpoint is registered with wrouter", nil),
 			}}},
 	})
 

--- a/conjure/visitors/visit_http_param.go
+++ b/conjure/visitors/visit_http_param.go
@@ -242,7 +242,7 @@ func (v *httpParamVisitor) VisitReference(t spec.TypeName) error {
 			RHS: expression.Nil,
 		},
 		Body: []astgen.ASTStmt{statement.NewReturn(werrorexpressions.CreateWrapWErrorExpression(
-			"err", //TODO(bmoylan): This should be a conjure 400 error, right now it will return 500
+			expression.VariableVal("err"), //TODO(bmoylan): This should be a conjure 400 error, right now it will return 500
 			"failed to unmarshal argument",
 			map[string]string{
 				"argName": string(v.argName),

--- a/conjure/werrorexpressions/werror.go
+++ b/conjure/werrorexpressions/werror.go
@@ -24,29 +24,18 @@ import (
 const (
 	werrorPackage         = "werror"
 	wrapFunctionName      = "Wrap"
-	errorFunctionName     = "Error"
 	safeParamFunctionName = "SafeParam"
 )
 
-func CreateWrapWErrorExpression(errorVarName, message string, safeParams map[string]string) astgen.ASTExpr {
+func CreateWrapWErrorExpression(errorExpr astgen.ASTExpr, message string, safeParams map[string]string) astgen.ASTExpr {
 	params := []astgen.ASTExpr{
-		expression.VariableVal(errorVarName),
+		errorExpr,
 		expression.StringVal(message),
 	}
 	for _, s := range turnParamsIntoStatements(safeParams) {
 		params = append(params, s)
 	}
 	return expression.NewCallFunction(werrorPackage, wrapFunctionName, params...)
-}
-
-func CreateWErrorExpression(message string, safeParams map[string]string) astgen.ASTExpr {
-	params := []astgen.ASTExpr{
-		expression.StringVal(message),
-	}
-	for _, s := range turnParamsIntoStatements(safeParams) {
-		params = append(params, s)
-	}
-	return expression.NewCallFunction(werrorPackage, errorFunctionName, params...)
 }
 
 func turnParamsIntoStatements(safeParams map[string]string) []astgen.ASTExpr {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/danverbraganza/varcaser v0.0.0-20190207223536-e3fb03ee5b4c
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.0.1
-	github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7
+	github.com/palantir/conjure-go-runtime/v2 v2.1.0
 	github.com/palantir/go-ptimports/v2 v2.9.0
 	github.com/palantir/goastwriter v0.0.1
 	github.com/palantir/godel-conjure-plugin/v4 v4.4.0
@@ -21,8 +21,8 @@ require (
 	github.com/palantir/pkg/safelong v1.0.1
 	github.com/palantir/pkg/safeyaml v1.0.1
 	github.com/palantir/pkg/uuid v1.0.1
-	github.com/palantir/witchcraft-go-error v1.2.0
-	github.com/palantir/witchcraft-go-logging v1.5.0
+	github.com/palantir/witchcraft-go-error v1.3.0
+	github.com/palantir/witchcraft-go-logging v1.5.2
 	github.com/palantir/witchcraft-go-params v1.1.0
 	github.com/palantir/witchcraft-go-server v1.13.0
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/danverbraganza/varcaser v0.0.0-20190207223536-e3fb03ee5b4c
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.0.1
-	github.com/palantir/conjure-go-runtime/v2 v2.0.0
+	github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1
 	github.com/palantir/go-ptimports/v2 v2.9.0
 	github.com/palantir/goastwriter v0.0.1
 	github.com/palantir/godel-conjure-plugin/v4 v4.4.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/danverbraganza/varcaser v0.0.0-20190207223536-e3fb03ee5b4c
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.0.1
-	github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1
+	github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7
 	github.com/palantir/go-ptimports/v2 v2.9.0
 	github.com/palantir/goastwriter v0.0.1
 	github.com/palantir/godel-conjure-plugin/v4 v4.4.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/palantir/conjure-go-runtime v0.4.0 h1:xmSzYVv27wnKNCcmtamcO9XpI6+Yig/cNElomWU72f4=
 github.com/palantir/conjure-go-runtime v0.4.0/go.mod h1:7tsjwMKuzyqjGCpKI7bVbZ3T68nvoFFPj2UrcFIETtQ=
-github.com/palantir/conjure-go-runtime/v2 v2.0.0 h1:gX0AEIYm3ba8jrT8JxGV/Nt6o5uZydLRxKvd/NgmByE=
-github.com/palantir/conjure-go-runtime/v2 v2.0.0/go.mod h1:1qIwDAoeK4UT8HIkrkyrGgkaMus/z2VA6Xe+efanr3U=
+github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1 h1:3hJtPPluVHUywyvX9gEsl//bAGbXzmS7xYj2u+9cu9M=
+github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1/go.mod h1:1qIwDAoeK4UT8HIkrkyrGgkaMus/z2VA6Xe+efanr3U=
 github.com/palantir/conjure-go/v4 v4.2.0/go.mod h1:VSVefkM94TdXRyP7wvBeURBNOFkYRJEtxPi8BeyKFi8=
 github.com/palantir/distgo v1.2.0/go.mod h1:jOCcoLD92T/eN4VfRxczaDIWsqyy1f0yQZMFOt3cJCw=
 github.com/palantir/distgo v1.20.0/go.mod h1:Jfsd7o7+kzCY8a3xpbPabr5IMjW6zSNOKLTNa8TJH4g=

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/palantir/conjure-go-runtime v0.4.0 h1:xmSzYVv27wnKNCcmtamcO9XpI6+Yig/cNElomWU72f4=
 github.com/palantir/conjure-go-runtime v0.4.0/go.mod h1:7tsjwMKuzyqjGCpKI7bVbZ3T68nvoFFPj2UrcFIETtQ=
-github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7 h1:CejRPVbS8v1IVD+GWP2UHWtF0xUqKBTQx9dx3MbBl3c=
-github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7/go.mod h1:1qIwDAoeK4UT8HIkrkyrGgkaMus/z2VA6Xe+efanr3U=
+github.com/palantir/conjure-go-runtime/v2 v2.1.0 h1:/n1abW2kqEx5zsSCb4bzrovK9ZhngIF9aZkUGQhXWp8=
+github.com/palantir/conjure-go-runtime/v2 v2.1.0/go.mod h1:k4+u7YJwBAO6Kk7SGvFCQR7vrkVW8vgQxO8rPZGuS5g=
 github.com/palantir/conjure-go/v4 v4.2.0/go.mod h1:VSVefkM94TdXRyP7wvBeURBNOFkYRJEtxPi8BeyKFi8=
 github.com/palantir/distgo v1.2.0/go.mod h1:jOCcoLD92T/eN4VfRxczaDIWsqyy1f0yQZMFOt3cJCw=
 github.com/palantir/distgo v1.20.0/go.mod h1:Jfsd7o7+kzCY8a3xpbPabr5IMjW6zSNOKLTNa8TJH4g=
@@ -184,8 +184,12 @@ github.com/palantir/pkg/uuid v1.0.1 h1:wcBLI2wA9IyCgE5o7z8jkfct74BHhC5iD8FNuqp8Z
 github.com/palantir/pkg/uuid v1.0.1/go.mod h1:pvQXYqMYf8GdAHEFiO4ROL9CEuNX7voJ7TjMPcx3NJo=
 github.com/palantir/witchcraft-go-error v1.2.0 h1:YFoZ8VC0ZLCGuhqM9iqdflUrTHGQmc3DC4GXGDZkhfY=
 github.com/palantir/witchcraft-go-error v1.2.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
+github.com/palantir/witchcraft-go-error v1.3.0 h1:1FUvIv+jS22t81uPI0Q5JEwzBDigClqGJJkLTuE8sZI=
+github.com/palantir/witchcraft-go-error v1.3.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
 github.com/palantir/witchcraft-go-logging v1.5.0 h1:LxmZ6XuhitMKmNrUQZ3UBU92q6PKPsawV94FlLVUui4=
 github.com/palantir/witchcraft-go-logging v1.5.0/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
+github.com/palantir/witchcraft-go-logging v1.5.2 h1:1xTnCqOSB5+BVlw4RkN3UWidhMxFT7nNNoRC1wA7scs=
+github.com/palantir/witchcraft-go-logging v1.5.2/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
 github.com/palantir/witchcraft-go-params v1.1.0 h1:siRqQv9TuJ0qY2JK5Svd3/rGQQCWvNnjI2OGAftm8gc=
 github.com/palantir/witchcraft-go-params v1.1.0/go.mod h1:HH+l5b0binfqBJ21qVvQVOJp6s2/I6ld0NEWnaEgWvI=
 github.com/palantir/witchcraft-go-server v1.13.0 h1:hT8z8vDtFJwb3GX1/+lufJMN+sk9H4xpsznYp8spBkc=
@@ -205,6 +209,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/zerolog v1.11.0 h1:DRuq/S+4k52uJzBQciUcofXx45GrMC6yrEbb/CoK6+M=
 github.com/rs/zerolog v1.11.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/palantir/conjure-go-runtime v0.4.0 h1:xmSzYVv27wnKNCcmtamcO9XpI6+Yig/cNElomWU72f4=
 github.com/palantir/conjure-go-runtime v0.4.0/go.mod h1:7tsjwMKuzyqjGCpKI7bVbZ3T68nvoFFPj2UrcFIETtQ=
-github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1 h1:3hJtPPluVHUywyvX9gEsl//bAGbXzmS7xYj2u+9cu9M=
-github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1/go.mod h1:1qIwDAoeK4UT8HIkrkyrGgkaMus/z2VA6Xe+efanr3U=
+github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7 h1:CejRPVbS8v1IVD+GWP2UHWtF0xUqKBTQx9dx3MbBl3c=
+github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7/go.mod h1:1qIwDAoeK4UT8HIkrkyrGgkaMus/z2VA6Xe+efanr3U=
 github.com/palantir/conjure-go/v4 v4.2.0/go.mod h1:VSVefkM94TdXRyP7wvBeURBNOFkYRJEtxPi8BeyKFi8=
 github.com/palantir/distgo v1.2.0/go.mod h1:jOCcoLD92T/eN4VfRxczaDIWsqyy1f0yQZMFOt3cJCw=
 github.com/palantir/distgo v1.20.0/go.mod h1:Jfsd7o7+kzCY8a3xpbPabr5IMjW6zSNOKLTNa8TJH4g=

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -51,7 +51,7 @@ type bothAuthServiceHandler struct {
 func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	respArg, err := b.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -64,7 +64,7 @@ func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http
 func (b *bothAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return b.impl.Cookie(req.Context(), cookieToken)
@@ -77,11 +77,11 @@ func (b *bothAuthServiceHandler) HandleNone(rw http.ResponseWriter, req *http.Re
 func (b *bothAuthServiceHandler) HandleWithArg(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var arg string
 	if err := codecs.JSON.Decode(req.Body, &arg); err != nil {
-		return errors.NewWrappedError(err, errors.NewInvalidArgument())
+		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
 	}
 	return b.impl.WithArg(req.Context(), bearertoken.Token(authHeader), arg)
 }
@@ -110,7 +110,7 @@ type cookieAuthServiceHandler struct {
 func (c *cookieAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return c.impl.Cookie(req.Context(), cookieToken)
@@ -140,7 +140,7 @@ type headerAuthServiceHandler struct {
 func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	respArg, err := h.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -178,7 +178,7 @@ type someHeaderAuthServiceHandler struct {
 func (s *someHeaderAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	respArg, err := s.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/pkg/bearertoken"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-server/rest"
@@ -50,7 +51,7 @@ type bothAuthServiceHandler struct {
 func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	respArg, err := b.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -63,7 +64,7 @@ func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http
 func (b *bothAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return b.impl.Cookie(req.Context(), cookieToken)
@@ -76,11 +77,11 @@ func (b *bothAuthServiceHandler) HandleNone(rw http.ResponseWriter, req *http.Re
 func (b *bothAuthServiceHandler) HandleWithArg(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var arg string
 	if err := codecs.JSON.Decode(req.Body, &arg); err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return errors.NewWrappedError(err, errors.NewInvalidArgument())
 	}
 	return b.impl.WithArg(req.Context(), bearertoken.Token(authHeader), arg)
 }
@@ -109,7 +110,7 @@ type cookieAuthServiceHandler struct {
 func (c *cookieAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return c.impl.Cookie(req.Context(), cookieToken)
@@ -139,7 +140,7 @@ type headerAuthServiceHandler struct {
 func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	respArg, err := h.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -177,7 +178,7 @@ type someHeaderAuthServiceHandler struct {
 func (s *someHeaderAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	respArg, err := s.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {

--- a/integration_test/testgenerated/client/api/servers.conjure.go
+++ b/integration_test/testgenerated/client/api/servers.conjure.go
@@ -70,7 +70,7 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 func (t *testServiceHandler) HandlePathParam(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	param, ok := pathParams["param"]
 	if !ok {
@@ -82,7 +82,7 @@ func (t *testServiceHandler) HandlePathParam(rw http.ResponseWriter, req *http.R
 func (t *testServiceHandler) HandlePathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {
@@ -99,7 +99,7 @@ func (t *testServiceHandler) HandlePathParamAlias(rw http.ResponseWriter, req *h
 func (t *testServiceHandler) HandlePathParamRid(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {
@@ -115,7 +115,7 @@ func (t *testServiceHandler) HandlePathParamRid(rw http.ResponseWriter, req *htt
 func (t *testServiceHandler) HandlePathParamRidAlias(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {

--- a/integration_test/testgenerated/client/api/servers.conjure.go
+++ b/integration_test/testgenerated/client/api/servers.conjure.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/pkg/rid"
 	"github.com/palantir/pkg/safejson"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -69,12 +70,11 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 func (t *testServiceHandler) HandlePathParam(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	param, ok := pathParams["param"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "param"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "param"))
 	}
 	return t.impl.PathParam(req.Context(), param)
 }
@@ -82,12 +82,11 @@ func (t *testServiceHandler) HandlePathParam(rw http.ResponseWriter, req *http.R
 func (t *testServiceHandler) HandlePathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "param"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "param"))
 	}
 	var param StringAlias
 	paramQuote := strconv.Quote(paramStr)
@@ -100,12 +99,11 @@ func (t *testServiceHandler) HandlePathParamAlias(rw http.ResponseWriter, req *h
 func (t *testServiceHandler) HandlePathParamRid(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "param"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "param"))
 	}
 	param, err := rid.ParseRID(paramStr)
 	if err != nil {
@@ -117,12 +115,11 @@ func (t *testServiceHandler) HandlePathParamRid(rw http.ResponseWriter, req *htt
 func (t *testServiceHandler) HandlePathParamRidAlias(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	paramStr, ok := pathParams["param"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "param"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "param"))
 	}
 	var param RidAlias
 	paramQuote := strconv.Quote(paramStr)

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
@@ -37,7 +38,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	var input string
 	if err := codecs.JSON.Decode(req.Body, &input); err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return errors.NewWrappedError(err, errors.NewInvalidArgument())
 	}
 	respArg, err := t.impl.Echo(req.Context(), input)
 	if err != nil {

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -38,7 +38,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	var input string
 	if err := codecs.JSON.Decode(req.Body, &input); err != nil {
-		return errors.NewWrappedError(err, errors.NewInvalidArgument())
+		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
 	}
 	respArg, err := t.impl.Echo(req.Context(), input)
 	if err != nil {

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/pkg/bearertoken"
 	"github.com/palantir/pkg/datetime"
 	"github.com/palantir/pkg/rid"
@@ -114,7 +115,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("PALANTIR_TOKEN")
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return t.impl.Echo(req.Context(), cookieToken)
@@ -123,16 +124,15 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParam, ok := pathParams["myPathParam"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "myPathParam"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam"))
 	}
 	return t.impl.GetPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam)
 }
@@ -140,16 +140,15 @@ func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *htt
 func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParamStr, ok := pathParams["myPathParam"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "myPathParam"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam"))
 	}
 	var myPathParam StringAlias
 	myPathParamQuote := strconv.Quote(myPathParamStr)
@@ -162,7 +161,7 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamList(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -171,7 +170,7 @@ func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *h
 func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []bool
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -187,7 +186,7 @@ func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []datetime.DateTime
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -203,7 +202,7 @@ func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []float64
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -219,7 +218,7 @@ func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []int
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -235,7 +234,7 @@ func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []rid.ResourceIdentifier
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -251,7 +250,7 @@ func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []safelong.SafeLong
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -267,7 +266,7 @@ func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamListString(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -276,7 +275,7 @@ func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	var myQueryParam1 []uuid.UUID
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -292,21 +291,19 @@ func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, re
 func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusForbidden))
+		return errors.NewWrappedError(err, errors.NewPermissionDenied())
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParam1, ok := pathParams["myPathParam1"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "myPathParam1"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam1"))
 	}
 	myPathParam2Str, ok := pathParams["myPathParam2"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "myPathParam2"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam2"))
 	}
 	myPathParam2, err := strconv.ParseBool(myPathParam2Str)
 	if err != nil {
@@ -345,7 +342,7 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 	}
 	var myBodyParam CustomObject
 	if err := codecs.JSON.Decode(req.Body, &myBodyParam); err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return errors.NewWrappedError(err, errors.NewInvalidArgument())
 	}
 	respArg, err := t.impl.PostPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam1, myPathParam2, myBodyParam, myQueryParam1, myQueryParam2, myQueryParam3, myQueryParam4, myQueryParam5, myHeaderParam1, myHeaderParam2)
 	if err != nil {
@@ -391,12 +388,11 @@ func (t *testServiceHandler) HandlePutBinary(rw http.ResponseWriter, req *http.R
 func (t *testServiceHandler) HandleChan(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Error("path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	var_, ok := pathParams["var"]
 	if !ok {
-		err := werror.Error("path param not present", werror.SafeParam("pathParamName", "var"))
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "var"))
 	}
 	type_ := req.URL.Query().Get("type")
 	return_, err := safelong.ParseSafeLong(req.Header.Get("X-My-Header2"))
@@ -405,7 +401,7 @@ func (t *testServiceHandler) HandleChan(rw http.ResponseWriter, req *http.Reques
 	}
 	var import_ map[string]string
 	if err := codecs.JSON.Decode(req.Body, &import_); err != nil {
-		return rest.NewError(err, rest.StatusCode(http.StatusBadRequest))
+		return errors.NewWrappedError(err, errors.NewInvalidArgument())
 	}
 	return t.impl.Chan(req.Context(), var_, import_, type_, return_)
 }

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -115,7 +115,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("PALANTIR_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return t.impl.Echo(req.Context(), cookieToken)
@@ -124,7 +124,7 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -140,7 +140,7 @@ func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *htt
 func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -161,7 +161,7 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamList(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -170,7 +170,7 @@ func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *h
 func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []bool
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -186,7 +186,7 @@ func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []datetime.DateTime
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -202,7 +202,7 @@ func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []float64
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -218,7 +218,7 @@ func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []int
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -234,7 +234,7 @@ func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []rid.ResourceIdentifier
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -250,7 +250,7 @@ func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []safelong.SafeLong
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -266,7 +266,7 @@ func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamListString(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -275,7 +275,7 @@ func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	var myQueryParam1 []uuid.UUID
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -291,7 +291,7 @@ func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, re
 func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := rest.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(err, errors.NewPermissionDenied())
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -342,7 +342,7 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 	}
 	var myBodyParam CustomObject
 	if err := codecs.JSON.Decode(req.Body, &myBodyParam); err != nil {
-		return errors.NewWrappedError(err, errors.NewInvalidArgument())
+		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
 	}
 	respArg, err := t.impl.PostPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam1, myPathParam2, myBodyParam, myQueryParam1, myQueryParam2, myQueryParam3, myQueryParam4, myQueryParam5, myHeaderParam1, myHeaderParam2)
 	if err != nil {
@@ -401,7 +401,7 @@ func (t *testServiceHandler) HandleChan(rw http.ResponseWriter, req *http.Reques
 	}
 	var import_ map[string]string
 	if err := codecs.JSON.Decode(req.Body, &import_); err != nil {
-		return errors.NewWrappedError(err, errors.NewInvalidArgument())
+		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
 	}
 	return t.impl.Chan(req.Context(), var_, import_, type_, return_)
 }

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -128,7 +128,7 @@ func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *htt
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParam, ok := pathParams["myPathParam"]
 	if !ok {
@@ -144,7 +144,7 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParamStr, ok := pathParams["myPathParam"]
 	if !ok {
@@ -295,7 +295,7 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	myPathParam1, ok := pathParams["myPathParam1"]
 	if !ok {
@@ -388,7 +388,7 @@ func (t *testServiceHandler) HandlePutBinary(rw http.ResponseWriter, req *http.R
 func (t *testServiceHandler) HandleChan(rw http.ResponseWriter, req *http.Request) error {
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
-		return werror.Wrap(errors.NewNotFound(), "path params not found on request: ensure this endpoint is registered with wrouter")
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
 	var_, ok := pathParams["var"]
 	if !ok {

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors/wrap.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors/wrap.go
@@ -22,7 +22,10 @@ import (
 // NewWrappedError is a convenience function for adding an underlying error to a conjure error
 // as additional context. This exists so that the conjure error becomes the RootCause, which is
 // used to extract the conjure error for serialization when returned by a server handler.
-func NewWrappedError(err error, conjureErr Error) error {
+//
+// The conjure error is wrapped using err's Error() message, and params if ParamStorer is implemented.
+// All other context is discarded, including cause stack (i.e. stacktrace) and type information.
+func NewWrappedError(conjureErr Error, err error) error {
 	if storer, ok := err.(wparams.ParamStorer); ok {
 		return werror.Wrap(conjureErr, err.Error(), werror.Params(storer))
 	}

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors/wrap.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors/wrap.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	werror "github.com/palantir/witchcraft-go-error"
+	wparams "github.com/palantir/witchcraft-go-params"
+)
+
+// NewWrappedError is a convenience function for adding an underlying error to a conjure error
+// as additional context. This exists so that the conjure error becomes the RootCause, which is
+// used to extract the conjure error for serialization when returned by a server handler.
+func NewWrappedError(err error, conjureErr Error) error {
+	if storer, ok := err.(wparams.ParamStorer); ok {
+		return werror.Wrap(conjureErr, err.Error(), werror.Params(storer))
+	}
+	return werror.Wrap(conjureErr, err.Error())
+}

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/logger_provider_jsonmarshal.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/logger_provider_jsonmarshal.go
@@ -41,37 +41,33 @@ func (l *jsonMapLogger) Log(params ...Param) {
 func (l *jsonMapLogger) Debug(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel:
-		l.logOutputWithMessage(msg, "DEBUG", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "DEBUG")))
 	}
 }
 
 func (l *jsonMapLogger) Info(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel:
-		l.logOutputWithMessage(msg, "INFO", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "INFO")))
 	}
 }
 
 func (l *jsonMapLogger) Warn(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel:
-		l.logOutputWithMessage(msg, "WARN", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "WARN")))
 	}
 }
 
 func (l *jsonMapLogger) Error(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
-		l.logOutputWithMessage(msg, "ERROR", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "ERROR")))
 	}
 }
 
 func (l *jsonMapLogger) SetLevel(level LogLevel) {
 	l.level = level
-}
-
-func (l *jsonMapLogger) logOutputWithMessage(msg, level string, params []Param) {
-	l.logOutput(append(params, StringParam("message", msg), StringParam("level", level)))
 }
 
 func (l *jsonMapLogger) logOutput(params []Param) {

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	typeValue = "request.2"
+	TypeValue = "request.2"
 
 	methodKey       = "method"
 	protocolKey     = "protocol"

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger_default.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger_default.go
@@ -42,7 +42,7 @@ func (l *defaultLogger) Request(r Request) {
 	idsMap := l.idsExtractor.ExtractIDs(r.Request)
 
 	l.logger.Log(
-		wlog.StringParam(wlog.TypeKey, typeValue),
+		wlog.StringParam(wlog.TypeKey, TypeValue),
 		wlog.OptionalStringParam(methodKey, r.Request.Method),
 		wlog.StringParam(protocolKey, r.Request.Proto),
 		wlog.StringParam(pathKey, reqPath),

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/params.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/params.go
@@ -119,7 +119,7 @@ func OriginFromInitPkg(skipPkg int) Param {
 func OriginFromCallLine() Param {
 	return paramFunc(func(entry wlog.LogEntry) {
 		origin := ""
-		if file, line, ok := initLineCaller(9); ok {
+		if file, line, ok := initLineCaller(8); ok {
 			origin = file + ":" + strconv.Itoa(line)
 		}
 		entry.OptionalStringValue(OriginKey, origin)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1
+# github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal
 github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507204807-58f0ab5de9b7
+# github.com/palantir/conjure-go-runtime/v2 v2.1.0
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal
 github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs
@@ -95,10 +95,10 @@ github.com/palantir/pkg/transform
 # github.com/palantir/pkg/uuid v1.0.1
 github.com/palantir/pkg/uuid
 github.com/palantir/pkg/uuid/internal/uuid
-# github.com/palantir/witchcraft-go-error v1.2.0
+# github.com/palantir/witchcraft-go-error v1.3.0
 github.com/palantir/witchcraft-go-error
 github.com/palantir/witchcraft-go-error/internal/errors
-# github.com/palantir/witchcraft-go-logging v1.5.0
+# github.com/palantir/witchcraft-go-logging v1.5.2
 github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging
 github.com/palantir/witchcraft-go-logging/internal/gopath
 github.com/palantir/witchcraft-go-logging/wlog

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v2 v2.0.0
+# github.com/palantir/conjure-go-runtime/v2 v2.0.1-0.20200507182302-1fe6c0f027c1
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal
 github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs


### PR DESCRIPTION
## Before this PR
Conjure generated servers emitted generic errors, which cannot be deserialized by the client.

## After this PR
==COMMIT_MSG==
Generated servers emit conjure errors, which the client is able to deserialize and log with associated safe/unsafe params.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/117)
<!-- Reviewable:end -->
