### PR TITLE
Break: Migrate from rest pkg -> conjure-go-server

### DIFF
--- a/changelog/@unreleased/pr-118.v2.yml
+++ b/changelog/@unreleased/pr-118.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: Conjure generated servers now use the `github.com/palantir/conjure-go-runtime/conjure-go-server`
+    library for request handling. This change correctly handles conjure error status
+    codes and prioritizes them over any legacy error code. It also writes non-json-marshalable
+    errors as plaintext with the correct headers.
+  links:
+  - https://github.com/palantir/conjure-go/pull/118

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -52,7 +52,7 @@ const (
 	// Server
 	serverResourceImportPackage = "wresource"
 	serverResourceFunctionName  = "New"
-	restImportPackage           = "rest"
+	httpserverImportPackage     = "httpserver"
 
 	// Errors
 	errorsImportPackage = "errors"
@@ -87,7 +87,7 @@ const (
 
 func ASTForServerRouteRegistration(serviceDefinition spec.ServiceDefinition, info types.PkgInfo) ([]astgen.ASTDecl, error) {
 	info.AddImports(
-		"github.com/palantir/witchcraft-go-server/rest",
+		"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver",
 		"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs",
 		"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors",
 		"github.com/palantir/witchcraft-go-server/witchcraft",
@@ -526,7 +526,7 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 					expression.VariableVal(errorName),
 				},
 				Tok: token.DEFINE,
-				RHS: expression.NewCallFunction(restImportPackage, funcParseBearerTokenHeader, expression.VariableVal(requestVarName)),
+				RHS: expression.NewCallFunction(httpserverImportPackage, funcParseBearerTokenHeader, expression.VariableVal(requestVarName)),
 			},
 			&statement.If{
 				Cond: getIfErrNotNilExpression(),
@@ -796,9 +796,9 @@ func getReceiverName(serviceDefinition spec.ServiceDefinition) string {
 
 // rest.NewJSONHandler(funcExpr, rest.StatusCodeMapper, rest.ErrHandler)
 func astForRestJSONHandler(funcExpr astgen.ASTExpr) astgen.ASTExpr {
-	return expression.NewCallFunction(restImportPackage, "NewJSONHandler",
+	return expression.NewCallFunction(httpserverImportPackage, "NewJSONHandler",
 		funcExpr,
-		expression.NewSelector(expression.VariableVal(restImportPackage), "StatusCodeMapper"),
-		expression.NewSelector(expression.VariableVal(restImportPackage), "ErrHandler"),
+		expression.NewSelector(expression.VariableVal(httpserverImportPackage), "StatusCodeMapper"),
+		expression.NewSelector(expression.VariableVal(httpserverImportPackage), "ErrHandler"),
 	)
 }

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/bearertoken"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
@@ -29,16 +29,16 @@ type BothAuthService interface {
 func RegisterRoutesBothAuthService(router wrouter.Router, impl BothAuthService) error {
 	handler := bothAuthServiceHandler{impl: impl}
 	resource := wresource.New("bothauthservice", router)
-	if err := resource.Get("Default", "/default", rest.NewJSONHandler(handler.HandleDefault, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Default", "/default", httpserver.NewJSONHandler(handler.HandleDefault, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Default"))
 	}
-	if err := resource.Get("Cookie", "/cookie", rest.NewJSONHandler(handler.HandleCookie, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Cookie", "/cookie", httpserver.NewJSONHandler(handler.HandleCookie, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Cookie"))
 	}
-	if err := resource.Get("None", "/none", rest.NewJSONHandler(handler.HandleNone, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("None", "/none", httpserver.NewJSONHandler(handler.HandleNone, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "None"))
 	}
-	if err := resource.Post("WithArg", "/withArg", rest.NewJSONHandler(handler.HandleWithArg, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Post("WithArg", "/withArg", httpserver.NewJSONHandler(handler.HandleWithArg, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "WithArg"))
 	}
 	return nil
@@ -49,7 +49,7 @@ type bothAuthServiceHandler struct {
 }
 
 func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -75,7 +75,7 @@ func (b *bothAuthServiceHandler) HandleNone(rw http.ResponseWriter, req *http.Re
 }
 
 func (b *bothAuthServiceHandler) HandleWithArg(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -97,7 +97,7 @@ type CookieAuthService interface {
 func RegisterRoutesCookieAuthService(router wrouter.Router, impl CookieAuthService) error {
 	handler := cookieAuthServiceHandler{impl: impl}
 	resource := wresource.New("cookieauthservice", router)
-	if err := resource.Get("Cookie", "/cookie", rest.NewJSONHandler(handler.HandleCookie, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Cookie", "/cookie", httpserver.NewJSONHandler(handler.HandleCookie, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Cookie"))
 	}
 	return nil
@@ -127,7 +127,7 @@ type HeaderAuthService interface {
 func RegisterRoutesHeaderAuthService(router wrouter.Router, impl HeaderAuthService) error {
 	handler := headerAuthServiceHandler{impl: impl}
 	resource := wresource.New("headerauthservice", router)
-	if err := resource.Get("Default", "/default", rest.NewJSONHandler(handler.HandleDefault, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Default", "/default", httpserver.NewJSONHandler(handler.HandleDefault, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Default"))
 	}
 	return nil
@@ -138,7 +138,7 @@ type headerAuthServiceHandler struct {
 }
 
 func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -162,10 +162,10 @@ type SomeHeaderAuthService interface {
 func RegisterRoutesSomeHeaderAuthService(router wrouter.Router, impl SomeHeaderAuthService) error {
 	handler := someHeaderAuthServiceHandler{impl: impl}
 	resource := wresource.New("someheaderauthservice", router)
-	if err := resource.Get("Default", "/default", rest.NewJSONHandler(handler.HandleDefault, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Default", "/default", httpserver.NewJSONHandler(handler.HandleDefault, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Default"))
 	}
-	if err := resource.Get("None", "/none", rest.NewJSONHandler(handler.HandleNone, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("None", "/none", httpserver.NewJSONHandler(handler.HandleNone, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "None"))
 	}
 	return nil
@@ -176,7 +176,7 @@ type someHeaderAuthServiceHandler struct {
 }
 
 func (s *someHeaderAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}

--- a/integration_test/testgenerated/auth/auth_test.go
+++ b/integration_test/testgenerated/auth/auth_test.go
@@ -62,7 +62,7 @@ func TestBothAuthClient(t *testing.T) {
 
 	// test invalid auth
 	_, err = client.Default(ctx, "invalid token")
-	assert.EqualError(t, err, "httpclient request failed: failed to unmarshal body as conjure error: json: cannot unmarshal string into Go value of type struct { Name string \"json:\\\"errorName\\\"\" }")
+	assert.Contains(t, err.Error(), "httpclient request failed: PERMISSION_DENIED Default:PermissionDenied")
 
 	// test cookie auth calls
 	err = client.Cookie(ctx, testJWT)

--- a/integration_test/testgenerated/client/api/servers.conjure.go
+++ b/integration_test/testgenerated/client/api/servers.conjure.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/rid"
 	"github.com/palantir/pkg/safejson"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
@@ -35,25 +35,25 @@ type TestService interface {
 func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	handler := testServiceHandler{impl: impl}
 	resource := wresource.New("testservice", router)
-	if err := resource.Get("Echo", "/echo", rest.NewJSONHandler(handler.HandleEcho, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Echo", "/echo", httpserver.NewJSONHandler(handler.HandleEcho, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Echo"))
 	}
-	if err := resource.Get("PathParam", "/path/{param}", rest.NewJSONHandler(handler.HandlePathParam, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("PathParam", "/path/{param}", httpserver.NewJSONHandler(handler.HandlePathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PathParam"))
 	}
-	if err := resource.Get("PathParamAlias", "/path/alias/{param}", rest.NewJSONHandler(handler.HandlePathParamAlias, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("PathParamAlias", "/path/alias/{param}", httpserver.NewJSONHandler(handler.HandlePathParamAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PathParamAlias"))
 	}
-	if err := resource.Get("PathParamRid", "/path/rid/{param}", rest.NewJSONHandler(handler.HandlePathParamRid, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("PathParamRid", "/path/rid/{param}", httpserver.NewJSONHandler(handler.HandlePathParamRid, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PathParamRid"))
 	}
-	if err := resource.Get("PathParamRidAlias", "/path/rid/alias/{param}", rest.NewJSONHandler(handler.HandlePathParamRidAlias, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("PathParamRidAlias", "/path/rid/alias/{param}", httpserver.NewJSONHandler(handler.HandlePathParamRidAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PathParamRidAlias"))
 	}
-	if err := resource.Get("Bytes", "/bytes", rest.NewJSONHandler(handler.HandleBytes, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Bytes", "/bytes", httpserver.NewJSONHandler(handler.HandleBytes, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Bytes"))
 	}
-	if err := resource.Get("Binary", "/binary", rest.NewJSONHandler(handler.HandleBinary, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Binary", "/binary", httpserver.NewJSONHandler(handler.HandleBinary, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Binary"))
 	}
 	return nil

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
@@ -25,7 +25,7 @@ type TestService interface {
 func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	handler := testServiceHandler{impl: impl}
 	resource := wresource.New("testservice", router)
-	if err := resource.Post("Echo", "/echo", rest.NewJSONHandler(handler.HandleEcho, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Post("Echo", "/echo", httpserver.NewJSONHandler(handler.HandleEcho, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Echo"))
 	}
 	return nil

--- a/integration_test/testgenerated/queryparam/api/servers.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/servers.conjure.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
@@ -25,7 +25,7 @@ type TestService interface {
 func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	handler := testServiceHandler{impl: impl}
 	resource := wresource.New("testservice", router)
-	if err := resource.Get("Echo", "/echo", rest.NewJSONHandler(handler.HandleEcho, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Echo", "/echo", httpserver.NewJSONHandler(handler.HandleEcho, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Echo"))
 	}
 	return nil

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/bearertoken"
 	"github.com/palantir/pkg/datetime"
 	"github.com/palantir/pkg/rid"
@@ -17,7 +18,6 @@ import (
 	"github.com/palantir/pkg/safelong"
 	"github.com/palantir/pkg/uuid"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-server/rest"
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 )
@@ -51,58 +51,58 @@ type TestService interface {
 func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	handler := testServiceHandler{impl: impl}
 	resource := wresource.New("testservice", router)
-	if err := resource.Get("Echo", "/echo", rest.NewJSONHandler(handler.HandleEcho, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Echo", "/echo", httpserver.NewJSONHandler(handler.HandleEcho, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Echo"))
 	}
-	if err := resource.Get("GetPathParam", "/path/{myPathParam}", rest.NewJSONHandler(handler.HandleGetPathParam, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("GetPathParam", "/path/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetPathParam"))
 	}
-	if err := resource.Get("GetPathParamAlias", "/path/alias/{myPathParam}", rest.NewJSONHandler(handler.HandleGetPathParamAlias, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("GetPathParamAlias", "/path/alias/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParamAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetPathParamAlias"))
 	}
-	if err := resource.Get("QueryParamList", "/pathNew", rest.NewJSONHandler(handler.HandleQueryParamList, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamList", "/pathNew", httpserver.NewJSONHandler(handler.HandleQueryParamList, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamList"))
 	}
-	if err := resource.Get("QueryParamListBoolean", "/booleanListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListBoolean, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListBoolean", "/booleanListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListBoolean, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListBoolean"))
 	}
-	if err := resource.Get("QueryParamListDateTime", "/dateTimeListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListDateTime, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListDateTime", "/dateTimeListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListDateTime, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListDateTime"))
 	}
-	if err := resource.Get("QueryParamListDouble", "/doubleListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListDouble, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListDouble", "/doubleListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListDouble, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListDouble"))
 	}
-	if err := resource.Get("QueryParamListInteger", "/intListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListInteger, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListInteger", "/intListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListInteger, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListInteger"))
 	}
-	if err := resource.Get("QueryParamListRid", "/ridListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListRid, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListRid", "/ridListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListRid, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListRid"))
 	}
-	if err := resource.Get("QueryParamListSafeLong", "/safeLongListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListSafeLong, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListSafeLong", "/safeLongListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListSafeLong, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListSafeLong"))
 	}
-	if err := resource.Get("QueryParamListString", "/stringListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListString, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListString", "/stringListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListString, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListString"))
 	}
-	if err := resource.Get("QueryParamListUuid", "/uuidListQueryVar", rest.NewJSONHandler(handler.HandleQueryParamListUuid, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("QueryParamListUuid", "/uuidListQueryVar", httpserver.NewJSONHandler(handler.HandleQueryParamListUuid, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamListUuid"))
 	}
-	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", rest.NewJSONHandler(handler.HandlePostPathParam, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PostPathParam"))
 	}
-	if err := resource.Get("Bytes", "/bytes", rest.NewJSONHandler(handler.HandleBytes, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("Bytes", "/bytes", httpserver.NewJSONHandler(handler.HandleBytes, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Bytes"))
 	}
-	if err := resource.Get("GetBinary", "/binary", rest.NewJSONHandler(handler.HandleGetBinary, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Get("GetBinary", "/binary", httpserver.NewJSONHandler(handler.HandleGetBinary, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetBinary"))
 	}
-	if err := resource.Post("PostBinary", "/binary", rest.NewJSONHandler(handler.HandlePostBinary, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Post("PostBinary", "/binary", httpserver.NewJSONHandler(handler.HandlePostBinary, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PostBinary"))
 	}
-	if err := resource.Put("PutBinary", "/binary", rest.NewJSONHandler(handler.HandlePutBinary, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Put("PutBinary", "/binary", httpserver.NewJSONHandler(handler.HandlePutBinary, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PutBinary"))
 	}
-	if err := resource.Post("Chan", "/chan/{var}", rest.NewJSONHandler(handler.HandleChan, rest.StatusCodeMapper, rest.ErrHandler)); err != nil {
+	if err := resource.Post("Chan", "/chan/{var}", httpserver.NewJSONHandler(handler.HandleChan, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Chan"))
 	}
 	return nil
@@ -122,7 +122,7 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 }
 
 func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -138,7 +138,7 @@ func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *htt
 }
 
 func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -159,7 +159,7 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 }
 
 func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -168,7 +168,7 @@ func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *h
 }
 
 func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -184,7 +184,7 @@ func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter,
 }
 
 func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -200,7 +200,7 @@ func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter
 }
 
 func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -216,7 +216,7 @@ func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, 
 }
 
 func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -232,7 +232,7 @@ func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter,
 }
 
 func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -248,7 +248,7 @@ func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req
 }
 
 func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -264,7 +264,7 @@ func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter
 }
 
 func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -273,7 +273,7 @@ func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, 
 }
 
 func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}
@@ -289,7 +289,7 @@ func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, re
 }
 
 func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := rest.ParseBearerTokenHeader(req)
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
 		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
 	}

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/errors.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/errors.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+const (
+	// legacyHTTPStatusCodeParamKey is the legacy parameter set by github.com/palantir/witchcraft-go-server/rest.NewError
+	legacyHTTPStatusCodeParamKey = "httpStatusCode"
+)

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/handlers.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/handlers.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+type ErrorHandler func(ctx context.Context, statusCode int, err error)
+type StatusMapper func(err error) int
+
+type handler struct {
+	handleFn func(http.ResponseWriter, *http.Request) error
+	statusFn StatusMapper
+	errorFn  ErrorHandler
+}
+
+// NewJSONHandler returns a http.Handler which will convert a returned error into a corresponding status code, and
+// handle the error according to the provided ErrorHandler. The provided 'fn' function is not expected to write
+// a response in the http.ResponseWriter if it returns a non-nil error. If a non-nil error is returned, the
+// mapped status code from the provided StatusMapper will be returned.
+func NewJSONHandler(fn func(http.ResponseWriter, *http.Request) error, statusFn StatusMapper, errorFn ErrorHandler) http.Handler {
+	return &handler{
+		handleFn: fn,
+		statusFn: statusFn,
+		errorFn:  errorFn,
+	}
+}
+
+// ServeHTTP implements the http.Handler interface
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := h.handleFn(w, r); err != nil {
+		status := h.status(err)
+		h.handleError(r.Context(), status, err)
+		if marshaler, ok := werror.RootCause(err).(json.Marshaler); ok {
+			WriteJSONResponse(w, marshaler, status)
+			return
+		}
+		// Fall back to string encoding
+		http.Error(w, err.Error(), status)
+		return
+	}
+}
+
+// status returns the http status code from the provided err
+func (h handler) status(err error) int {
+	if h.statusFn != nil {
+		return h.statusFn(err)
+	}
+	return http.StatusInternalServerError
+}
+
+// handleError calls the handler's provided ErrorHandler with the provided error
+func (h handler) handleError(ctx context.Context, statusCode int, err error) {
+	if h.errorFn != nil {
+		h.errorFn(ctx, statusCode, err)
+	}
+}
+
+// StatusCodeMapper maps a provided error to an HTTP status code.
+// If the error's RootCause is a conjure error, the status mapping to the errorCode field is used.
+// If the provided error is a contains the legacy httpStatusCode parameter, that value is used.
+// Otherwise, returns http.StatusInternalServerError (500).
+func StatusCodeMapper(err error) int {
+	if conjureErr, ok := werror.RootCause(err).(errors.Error); ok {
+		return conjureErr.Code().StatusCode()
+	}
+	if legacyCode := legacyErrorCode(err); legacyCode != 0 {
+		return legacyCode
+	}
+	return http.StatusInternalServerError
+}
+
+// legacyErrorCode extracts error codes set by the deprecated witchcraft-go-server/rest package.
+// It returns 0 if not found. New code should use conjure errors.
+func legacyErrorCode(err error) int {
+	statusCodeParam, _ := werror.ParamFromError(err, legacyHTTPStatusCodeParamKey)
+	if statusCodeParam == nil {
+		return 0
+	}
+	statusCodeInt, ok := statusCodeParam.(int)
+	if !ok {
+		return 0
+	}
+	return statusCodeInt
+}
+
+// ErrHandler is an ErrorHandler that creates a log in the provided context's svc1log logger when an error is received.
+// The log output is printed at the ERROR level if the status code is >= 500; otherwise, it is printed at INFO level.
+// This preserves request-scoped logging configuration added by wrouter.
+func ErrHandler(ctx context.Context, statusCode int, err error) {
+	logger := svc1log.FromContext(ctx)
+
+	logFn := logger.Info
+	if statusCode >= 500 {
+		logFn = logger.Error
+	}
+	logFn(
+		fmt.Sprintf("error handling request: %s", err.Error()),
+		svc1log.Stacktrace(err),
+	)
+}

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/rest.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/rest.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/palantir/pkg/safejson"
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+// WriteJSONResponse marshals the provided object to JSON using a JSON encoder with SetEscapeHTML(false) and writes the
+// resulting JSON as a JSON response to the provided http.ResponseWriter with the provided status code. If marshaling
+// the provided object as JSON results in an error, writes a 500 response with the text content of the error.
+func WriteJSONResponse(w http.ResponseWriter, obj interface{}, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if err := safejson.Encoder(w).Encode(obj); err != nil {
+		// if JSON encode failed, send error response. If JSON encode succeeded but write failed, then this
+		// should be a no-op since the socket failed anyway.
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// ParseBearerTokenHeader parses a bearer token value out of the Authorization header. It expects a header with a key
+// of 'Authorization' and a value of 'bearer {token}'. ParseBearerTokenHeader will return the token value, or an error
+// if the Authorization header is missing, an empty string, or is not in the format expected.
+func ParseBearerTokenHeader(req *http.Request) (string, error) {
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" {
+		return "", werror.Error("Authorization header not found")
+	}
+	headerSplit := strings.Split(authHeader, " ")
+	if len(headerSplit) != 2 || strings.ToLower(headerSplit[0]) != "bearer" {
+		return "", werror.Error("Illegal authorization header, expected Bearer")
+	}
+	return headerSplit[1], nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,6 +40,7 @@ github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal
 github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs
 github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors
+github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver
 # github.com/palantir/go-encrypted-config-value v1.1.0
 github.com/palantir/go-encrypted-config-value/encryptedconfigvalue
 github.com/palantir/go-encrypted-config-value/encryption


### PR DESCRIPTION
## Before this PR
Conjure generated servers used the `github.com/palantir/witchcraft-go-server/rest` library for request handling.

## After this PR
==COMMIT_MSG==
Conjure generated servers now use the `github.com/palantir/conjure-go-runtime/conjure-go-server` library for request handling. This change correctly handles conjure error status codes and prioritizes them over any legacy error code. It also writes non-json-marshalable errors as plaintext with the correct headers.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/118)
<!-- Reviewable:end -->
