### PR TITLE
Fix error constructors with fields that are type names

### DIFF
--- a/changelog/@unreleased/pr-124.v2.yml
+++ b/changelog/@unreleased/pr-124.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix error constructors with fields that are type names
+  links:
+  - https://github.com/palantir/conjure-go/pull/124

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2145,8 +2145,8 @@ func (o *myNotFound) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // NewMyNotFound returns new instance of MyNotFound error.
-func NewMyNotFound(safeArgA api.SimpleObject, safeArgB int, unsafeArgA string) *MyNotFound {
-	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgA, SafeArgB: safeArgB, UnsafeArgA: unsafeArgA}}
+func NewMyNotFound(safeArgAArg api.SimpleObject, safeArgBArg int, unsafeArgAArg string) *MyNotFound {
+	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgAArg, SafeArgB: safeArgBArg, UnsafeArgA: unsafeArgAArg}}
 }
 
 // MyNotFound is an error type.

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -79,12 +79,12 @@ func astForError(errorDefinition spec.ErrorDefinition, info types.PkgInfo) ([]as
 		}
 		goType := typer.GoType(info)
 		constructorParams = append(constructorParams, &expression.FuncParam{
-			Names: []string{transforms.SafeName(string(fieldDefinition.FieldName))},
+			Names: []string{argNameTransform(string(fieldDefinition.FieldName))},
 			Type:  expression.Type(goType),
 		})
 		paramToFieldAssignments = append(paramToFieldAssignments, expression.NewKeyValue(
 			transforms.Export(string(fieldDefinition.FieldName)),
-			expression.VariableVal(transforms.SafeName(string(fieldDefinition.FieldName))),
+			expression.VariableVal(argNameTransform(string(fieldDefinition.FieldName))),
 		))
 	}
 	decls = append(decls,

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -22,6 +22,7 @@ type myInternal struct {
 	Type       string  `json:"type" conjure-docs:"A field named with a go keyword"`
 	UnsafeArgA string  `json:"unsafeArgA"`
 	UnsafeArgB *string `json:"unsafeArgB"`
+	MyInternal string  `json:"myInternal"`
 }
 
 func (o myInternal) MarshalJSON() ([]byte, error) {
@@ -62,8 +63,8 @@ func (o *myInternal) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // NewMyInternal returns new instance of MyInternal error.
-func NewMyInternal(safeArgA Basic, safeArgB []int, type_ string, unsafeArgA string, unsafeArgB *string) *MyInternal {
-	return &MyInternal{errorInstanceID: uuid.NewUUID(), myInternal: myInternal{SafeArgA: safeArgA, SafeArgB: safeArgB, Type: type_, UnsafeArgA: unsafeArgA, UnsafeArgB: unsafeArgB}}
+func NewMyInternal(safeArgAArg Basic, safeArgBArg []int, typeArg string, unsafeArgAArg string, unsafeArgBArg *string, myInternalArg string) *MyInternal {
+	return &MyInternal{errorInstanceID: uuid.NewUUID(), myInternal: myInternal{SafeArgA: safeArgAArg, SafeArgB: safeArgBArg, Type: typeArg, UnsafeArgA: unsafeArgAArg, UnsafeArgB: unsafeArgBArg, MyInternal: myInternalArg}}
 }
 
 // MyInternal is an error type.
@@ -95,7 +96,7 @@ func (e *MyInternal) InstanceID() uuid.UUID {
 
 // Parameters returns a set of named parameters detailing this particular error instance.
 func (e *MyInternal) Parameters() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB, "myInternal": e.MyInternal}
 }
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance.
@@ -105,7 +106,7 @@ func (e *MyInternal) SafeParams() map[string]interface{} {
 
 // UnsafeParams returns a set of named unsafe parameters detailing this particular error instance.
 func (e *MyInternal) UnsafeParams() map[string]interface{} {
-	return map[string]interface{}{"unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB}
+	return map[string]interface{}{"unsafeArgA": e.UnsafeArgA, "unsafeArgB": e.UnsafeArgB, "myInternal": e.MyInternal}
 }
 
 func (e MyInternal) MarshalJSON() ([]byte, error) {
@@ -179,8 +180,8 @@ func (o *myNotFound) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // NewMyNotFound returns new instance of MyNotFound error.
-func NewMyNotFound(safeArgA Basic, safeArgB []int, type_ string, unsafeArgA string, unsafeArgB *string) *MyNotFound {
-	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgA, SafeArgB: safeArgB, Type: type_, UnsafeArgA: unsafeArgA, UnsafeArgB: unsafeArgB}}
+func NewMyNotFound(safeArgAArg Basic, safeArgBArg []int, typeArg string, unsafeArgAArg string, unsafeArgBArg *string) *MyNotFound {
+	return &MyNotFound{errorInstanceID: uuid.NewUUID(), myNotFound: myNotFound{SafeArgA: safeArgAArg, SafeArgB: safeArgBArg, Type: typeArg, UnsafeArgA: unsafeArgAArg, UnsafeArgB: unsafeArgBArg}}
 }
 
 // MyNotFound is an error type.

--- a/integration_test/testgenerated/errors/errors.yml
+++ b/integration_test/testgenerated/errors/errors.yml
@@ -36,6 +36,8 @@ types:
         unsafe-args:
           unsafeArgA: string
           unsafeArgB: optional<string>
+          # An argument with the same (case-insensitive) name as the error type.
+          myInternal: string
     objects:
       Basic:
         fields:

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -69,6 +69,7 @@ var testErrorInternal = api.NewMyInternal(
 	"type",
 	"something",
 	nil,
+	"myInternalValue",
 )
 
 var testJSONInternal = fmt.Sprintf(`{
@@ -76,6 +77,7 @@ var testJSONInternal = fmt.Sprintf(`{
   "errorName": "MyNamespace:MyInternal",
   "errorInstanceId": "%s",
   "parameters": {
+    "myInternal": "myInternalValue",
     "safeArgA": {
       "data": "some data"
     },


### PR DESCRIPTION
## Before this PR
If an error used a parameter name that was also a type name, the constructor's function argument shadowed the type and the code does not compile.
## After this PR
==COMMIT_MSG==
Fix error constructors with fields that are type names
==COMMIT_MSG==

Fixes #96 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/124)
<!-- Reviewable:end -->
