### PR TITLE
Fix client sending list/set query params

### DIFF
--- a/changelog/@unreleased/pr-130.v2.yml
+++ b/changelog/@unreleased/pr-130.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Generated clients correctly set list/set query parameters as multiple
+    values
+  links:
+  - https://github.com/palantir/conjure-go/pull/130

--- a/integration_test/testgenerated/queryparam/api/servers.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/servers.conjure.go
@@ -15,7 +15,7 @@ import (
 )
 
 type TestService interface {
-	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, lastParamArg *string) (string, error)
+	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, listParamArg []int, lastParamArg *string) (string, error)
 }
 
 // RegisterRoutesTestService registers handlers for the TestService endpoints with a witchcraft wrouter.
@@ -46,12 +46,20 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 		optionalInternal := optionalStr
 		optional = &optionalInternal
 	}
+	var listParam []int
+	for _, v := range req.URL.Query()["listParam"] {
+		convertedVal, err := strconv.Atoi(v)
+		if err != nil {
+			return err
+		}
+		listParam = append(listParam, convertedVal)
+	}
 	var lastParam *string
 	if lastParamStr := req.URL.Query().Get("lastParam"); lastParamStr != "" {
 		lastParamInternal := lastParamStr
 		lastParam = &lastParamInternal
 	}
-	respArg, err := t.impl.Echo(req.Context(), input, reps, optional, lastParam)
+	respArg, err := t.impl.Echo(req.Context(), input, reps, optional, listParam, lastParam)
 	if err != nil {
 		return err
 	}

--- a/integration_test/testgenerated/queryparam/api/services.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/services.conjure.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TestServiceClient interface {
-	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, lastParamArg *string) (string, error)
+	Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, listParamArg []int, lastParamArg *string) (string, error)
 }
 
 type testServiceClient struct {
@@ -22,7 +22,7 @@ func NewTestServiceClient(client httpclient.Client) TestServiceClient {
 	return &testServiceClient{client: client}
 }
 
-func (c *testServiceClient) Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, lastParamArg *string) (string, error) {
+func (c *testServiceClient) Echo(ctx context.Context, inputArg string, repsArg int, optionalArg *string, listParamArg []int, lastParamArg *string) (string, error) {
 	var defaultReturnVal string
 	var returnVal *string
 	var requestParams []httpclient.RequestParam
@@ -34,6 +34,9 @@ func (c *testServiceClient) Echo(ctx context.Context, inputArg string, repsArg i
 	queryParams.Set("reps", fmt.Sprint(repsArg))
 	if optionalArg != nil {
 		queryParams.Set("optional", fmt.Sprint(*optionalArg))
+	}
+	for _, v := range listParamArg {
+		queryParams.Add("listParam", fmt.Sprint(v))
 	}
 	if lastParamArg != nil {
 		queryParams.Set("lastParam", fmt.Sprint(*lastParamArg))

--- a/integration_test/testgenerated/queryparam/query-service.yml
+++ b/integration_test/testgenerated/queryparam/query-service.yml
@@ -15,6 +15,9 @@ services:
           optional:
             type: optional<string>
             param-type: query
+          listParam:
+            type: list<integer>
+            param-type: query
           lastParam:
             type: optional<string>
             param-type: query

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -95,7 +95,9 @@ func (c *testServiceClient) QueryParamList(ctx context.Context, authHeader beare
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/pathNew"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -112,7 +114,9 @@ func (c *testServiceClient) QueryParamListBoolean(ctx context.Context, authHeade
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/booleanListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -129,7 +133,9 @@ func (c *testServiceClient) QueryParamListDateTime(ctx context.Context, authHead
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/dateTimeListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -146,7 +152,9 @@ func (c *testServiceClient) QueryParamListDouble(ctx context.Context, authHeader
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/doubleListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -163,7 +171,9 @@ func (c *testServiceClient) QueryParamListInteger(ctx context.Context, authHeade
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/intListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -180,7 +190,9 @@ func (c *testServiceClient) QueryParamListRid(ctx context.Context, authHeader be
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/ridListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -197,7 +209,9 @@ func (c *testServiceClient) QueryParamListSafeLong(ctx context.Context, authHead
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/safeLongListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -214,7 +228,9 @@ func (c *testServiceClient) QueryParamListString(ctx context.Context, authHeader
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/stringListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
@@ -231,7 +247,9 @@ func (c *testServiceClient) QueryParamListUuid(ctx context.Context, authHeader b
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
 	requestParams = append(requestParams, httpclient.WithPathf("/uuidListQueryVar"))
 	queryParams := make(url.Values)
-	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	for _, v := range myQueryParam1Arg {
+		queryParams.Add("myQueryParam1", fmt.Sprint(v))
+	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {


### PR DESCRIPTION
## Before this PR
Fixes #128: Bad request response for lists and sets as query parameters

## After this PR
==COMMIT_MSG==
Generated clients correctly set list/set query parameters as multiple values
==COMMIT_MSG==

## Possible downsides?
Technically a break to how clients send data over the wire, though I'm marking it as a bugfix since we were not in compliance with the spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/130)
<!-- Reviewable:end -->
