### PR TITLE
Server route registration recognizes com.palantir.logsafe.Safe argument marker

### DIFF
--- a/changelog/@unreleased/pr-138.v2.yml
+++ b/changelog/@unreleased/pr-138.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Server route registration recognizes `com.palantir.logsafe.Safe` argument
+    marker
+  links:
+  - https://github.com/palantir/conjure-go/pull/138

--- a/conjure/visitors/conjuretype_provider.go
+++ b/conjure/visitors/conjuretype_provider.go
@@ -23,14 +23,15 @@ import (
 type TypeCheck string
 
 const (
-	IsText     TypeCheck = "TEXT" // anything serialized as a string
-	IsOptional TypeCheck = "OPTIONAL"
-	IsBinary   TypeCheck = "BINARY"
-	IsString   TypeCheck = "STRING"
-	IsList     TypeCheck = "LIST"
-	IsMap      TypeCheck = "MAP"
-	IsSet      TypeCheck = "SET"
-	IsBoolean  TypeCheck = "BOOLEAN"
+	IsText       TypeCheck = "TEXT" // anything serialized as a string
+	IsOptional   TypeCheck = "OPTIONAL"
+	IsBinary     TypeCheck = "BINARY"
+	IsString     TypeCheck = "STRING"
+	IsList       TypeCheck = "LIST"
+	IsMap        TypeCheck = "MAP"
+	IsSet        TypeCheck = "SET"
+	IsBoolean    TypeCheck = "BOOLEAN"
+	IsSafeMarker TypeCheck = "SAFE_MARKER"
 )
 
 type ConjureTypeProvider interface {

--- a/conjure/visitors/conjuretype_visit_external.go
+++ b/conjure/visitors/conjuretype_visit_external.go
@@ -48,5 +48,9 @@ func (p *externalVisitor) CollectionInitializationIfNeeded(types.PkgInfo) (*expr
 }
 
 func (p *externalVisitor) IsSpecificType(typeCheck TypeCheck) bool {
+	if p != nil && typeCheck == IsSafeMarker {
+		ref := p.externalType.ExternalReference
+		return ref.Package == "com.palantir.logsafe" && ref.Name == "Safe"
+	}
 	return false
 }

--- a/conjure/visitors/conjuretype_visit_external_test.go
+++ b/conjure/visitors/conjuretype_visit_external_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/palantir/conjure-go/v5/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/v5/conjure/types"
@@ -42,5 +43,40 @@ func TestExternalTypeFallback(t *testing.T) {
 		assert.Equal(t, err, nil)
 		assert.Equal(t, types.String, typ)
 	})
+}
 
+func TestExternalType_IsSafeMarker(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		ref := spec.ExternalReference{
+			ExternalReference: spec.TypeName{
+				Name:    "Safe",
+				Package: "com.palantir.logsafe",
+			},
+		}
+		result, err := IsSpecificConjureType(spec.NewTypeFromExternal(ref), IsSafeMarker)
+		require.NoError(t, err)
+		assert.True(t, result)
+	})
+	t.Run("bad name", func(t *testing.T) {
+		ref := spec.ExternalReference{
+			ExternalReference: spec.TypeName{
+				Name:    "Unsafe",
+				Package: "com.palantir.logsafe",
+			},
+		}
+		result, err := IsSpecificConjureType(spec.NewTypeFromExternal(ref), IsSafeMarker)
+		require.NoError(t, err)
+		assert.False(t, result)
+	})
+	t.Run("bad pkg", func(t *testing.T) {
+		ref := spec.ExternalReference{
+			ExternalReference: spec.TypeName{
+				Name:    "Safe",
+				Package: "com.palantir.conjure",
+			},
+		}
+		result, err := IsSpecificConjureType(spec.NewTypeFromExternal(ref), IsSafeMarker)
+		require.NoError(t, err)
+		assert.False(t, result)
+	})
 }

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -24,8 +24,8 @@ import (
 
 type TestService interface {
 	Echo(ctx context.Context, cookieToken bearertoken.Token) error
-	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
 	GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error
+	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
 	QueryParamList(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListBoolean(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []bool) error
 	QueryParamListDateTime(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []datetime.DateTime) error
@@ -55,11 +55,11 @@ func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	if err := resource.Get("Echo", "/echo", httpserver.NewJSONHandler(handler.HandleEcho, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Echo"))
 	}
-	if err := resource.Get("GetPathParam", "/path/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
-		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetPathParam"))
-	}
 	if err := resource.Get("GetPathParamAlias", "/path/alias/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParamAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetPathParamAlias"))
+	}
+	if err := resource.Get("GetPathParam", "/path/string/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
+		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "GetPathParam"))
 	}
 	if err := resource.Get("QueryParamList", "/pathNew", httpserver.NewJSONHandler(handler.HandleQueryParamList, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "QueryParamList"))
@@ -125,22 +125,6 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 	return t.impl.Echo(req.Context(), cookieToken)
 }
 
-func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
-	authHeader, err := httpserver.ParseBearerTokenHeader(req)
-	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
-	}
-	pathParams := wrouter.PathParams(req)
-	if pathParams == nil {
-		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
-	}
-	myPathParam, ok := pathParams["myPathParam"]
-	if !ok {
-		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam"))
-	}
-	return t.impl.GetPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam)
-}
-
 func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
@@ -160,6 +144,22 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 		return werror.Wrap(err, "failed to unmarshal argument", werror.SafeParam("argName", "myPathParam"), werror.SafeParam("argType", "StringAlias"))
 	}
 	return t.impl.GetPathParamAlias(req.Context(), bearertoken.Token(authHeader), myPathParam)
+}
+
+func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
+	if err != nil {
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+	}
+	pathParams := wrouter.PathParams(req)
+	if pathParams == nil {
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
+	}
+	myPathParam, ok := pathParams["myPathParam"]
+	if !ok {
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam"))
+	}
+	return t.impl.GetPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam)
 }
 
 func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *http.Request) error {

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -36,6 +36,7 @@ type TestService interface {
 	QueryParamListString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListUuid(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []uuid.UUID) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
@@ -89,6 +90,9 @@ func RegisterRoutesTestService(router wrouter.Router, impl TestService) error {
 	}
 	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PostPathParam"))
+	}
+	if err := resource.Post("PostSafeParams", "/safe/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostSafeParams, httpserver.StatusCodeMapper, httpserver.ErrHandler), wrouter.SafePathParams("myPathParam1"), wrouter.SafeHeaderParams("X-My-Header1-Abc"), wrouter.SafeQueryParams("query1", "myQueryParam2")); err != nil {
+		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "PostSafeParams"))
 	}
 	if err := resource.Get("Bytes", "/bytes", httpserver.NewJSONHandler(handler.HandleBytes, httpserver.StatusCodeMapper, httpserver.ErrHandler)); err != nil {
 		return werror.Wrap(err, "failed to add route", werror.SafeParam("routeName", "Bytes"))
@@ -350,6 +354,65 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
+}
+
+func (t *testServiceHandler) HandlePostSafeParams(rw http.ResponseWriter, req *http.Request) error {
+	authHeader, err := httpserver.ParseBearerTokenHeader(req)
+	if err != nil {
+		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+	}
+	pathParams := wrouter.PathParams(req)
+	if pathParams == nil {
+		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
+	}
+	myPathParam1, ok := pathParams["myPathParam1"]
+	if !ok {
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam1"))
+	}
+	myPathParam2Str, ok := pathParams["myPathParam2"]
+	if !ok {
+		return werror.Wrap(errors.NewInvalidArgument(), "path param not present", werror.SafeParam("pathParamName", "myPathParam2"))
+	}
+	myPathParam2, err := strconv.ParseBool(myPathParam2Str)
+	if err != nil {
+		return err
+	}
+	myQueryParam1 := req.URL.Query().Get("query1")
+	myQueryParam2 := req.URL.Query().Get("myQueryParam2")
+	myQueryParam3, err := strconv.ParseFloat(req.URL.Query().Get("myQueryParam3"), 64)
+	if err != nil {
+		return err
+	}
+	var myQueryParam4 *safelong.SafeLong
+	if myQueryParam4Str := req.URL.Query().Get("myQueryParam4"); myQueryParam4Str != "" {
+		myQueryParam4Internal, err := safelong.ParseSafeLong(myQueryParam4Str)
+		if err != nil {
+			return err
+		}
+		myQueryParam4 = &myQueryParam4Internal
+	}
+	var myQueryParam5 *string
+	if myQueryParam5Str := req.URL.Query().Get("myQueryParam5"); myQueryParam5Str != "" {
+		myQueryParam5Internal := myQueryParam5Str
+		myQueryParam5 = &myQueryParam5Internal
+	}
+	myHeaderParam1, err := safelong.ParseSafeLong(req.Header.Get("X-My-Header1-Abc"))
+	if err != nil {
+		return err
+	}
+	var myHeaderParam2 *uuid.UUID
+	if myHeaderParam2Str := req.Header.Get("X-My-Header2"); myHeaderParam2Str != "" {
+		myHeaderParam2Internal, err := uuid.ParseUUID(myHeaderParam2Str)
+		if err != nil {
+			return err
+		}
+		myHeaderParam2 = &myHeaderParam2Internal
+	}
+	var myBodyParam CustomObject
+	if err := codecs.JSON.Decode(req.Body, &myBodyParam); err != nil {
+		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+	}
+	return t.impl.PostSafeParams(req.Context(), bearertoken.Token(authHeader), myPathParam1, myPathParam2, myBodyParam, myQueryParam1, myQueryParam2, myQueryParam3, myQueryParam4, myQueryParam5, myHeaderParam1, myHeaderParam2)
 }
 
 func (t *testServiceHandler) HandleBytes(rw http.ResponseWriter, req *http.Request) error {

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -18,8 +18,8 @@ import (
 
 type TestServiceClient interface {
 	Echo(ctx context.Context, cookieToken bearertoken.Token) error
-	GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error
 	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
+	GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error
 	QueryParamList(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListBoolean(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []bool) error
 	QueryParamListDateTime(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []datetime.DateTime) error
@@ -61,12 +61,12 @@ func (c *testServiceClient) Echo(ctx context.Context, cookieToken bearertoken.To
 	return nil
 }
 
-func (c *testServiceClient) GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error {
+func (c *testServiceClient) GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error {
 	var requestParams []httpclient.RequestParam
-	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParamAlias"))
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParam"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
-	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/string/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
 		return err
@@ -75,12 +75,12 @@ func (c *testServiceClient) GetPathParamAlias(ctx context.Context, authHeader be
 	return nil
 }
 
-func (c *testServiceClient) GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error {
+func (c *testServiceClient) GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error {
 	var requestParams []httpclient.RequestParam
-	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParam"))
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParamAlias"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
-	requestParams = append(requestParams, httpclient.WithPathf("/path/string/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
 		return err
@@ -406,8 +406,8 @@ func (c *testServiceClient) Chan(ctx context.Context, varArg string, importArg m
 
 type TestServiceClientWithAuth interface {
 	Echo(ctx context.Context) error
-	GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error
 	GetPathParam(ctx context.Context, myPathParamArg string) error
+	GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error
 	QueryParamList(ctx context.Context, myQueryParam1Arg []string) error
 	QueryParamListBoolean(ctx context.Context, myQueryParam1Arg []bool) error
 	QueryParamListDateTime(ctx context.Context, myQueryParam1Arg []datetime.DateTime) error
@@ -441,12 +441,12 @@ func (c *testServiceClientWithAuth) Echo(ctx context.Context) error {
 	return c.client.Echo(ctx, c.cookieToken)
 }
 
-func (c *testServiceClientWithAuth) GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error {
-	return c.client.GetPathParamAlias(ctx, c.authHeader, myPathParamArg)
-}
-
 func (c *testServiceClientWithAuth) GetPathParam(ctx context.Context, myPathParamArg string) error {
 	return c.client.GetPathParam(ctx, c.authHeader, myPathParamArg)
+}
+
+func (c *testServiceClientWithAuth) GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error {
+	return c.client.GetPathParamAlias(ctx, c.authHeader, myPathParamArg)
 }
 
 func (c *testServiceClientWithAuth) QueryParamList(ctx context.Context, myQueryParam1Arg []string) error {

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -18,8 +18,8 @@ import (
 
 type TestServiceClient interface {
 	Echo(ctx context.Context, cookieToken bearertoken.Token) error
-	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
 	GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error
+	GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error
 	QueryParamList(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListBoolean(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []bool) error
 	QueryParamListDateTime(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []datetime.DateTime) error
@@ -61,12 +61,12 @@ func (c *testServiceClient) Echo(ctx context.Context, cookieToken bearertoken.To
 	return nil
 }
 
-func (c *testServiceClient) GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error {
+func (c *testServiceClient) GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error {
 	var requestParams []httpclient.RequestParam
-	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParam"))
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParamAlias"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
-	requestParams = append(requestParams, httpclient.WithPathf("/path/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
 		return err
@@ -75,12 +75,12 @@ func (c *testServiceClient) GetPathParam(ctx context.Context, authHeader bearert
 	return nil
 }
 
-func (c *testServiceClient) GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg StringAlias) error {
+func (c *testServiceClient) GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error {
 	var requestParams []httpclient.RequestParam
-	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParamAlias"))
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("GetPathParam"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
 	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
-	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
+	requestParams = append(requestParams, httpclient.WithPathf("/path/string/%s", url.PathEscape(fmt.Sprint(myPathParamArg))))
 	resp, err := c.client.Do(ctx, requestParams...)
 	if err != nil {
 		return err
@@ -406,8 +406,8 @@ func (c *testServiceClient) Chan(ctx context.Context, varArg string, importArg m
 
 type TestServiceClientWithAuth interface {
 	Echo(ctx context.Context) error
-	GetPathParam(ctx context.Context, myPathParamArg string) error
 	GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error
+	GetPathParam(ctx context.Context, myPathParamArg string) error
 	QueryParamList(ctx context.Context, myQueryParam1Arg []string) error
 	QueryParamListBoolean(ctx context.Context, myQueryParam1Arg []bool) error
 	QueryParamListDateTime(ctx context.Context, myQueryParam1Arg []datetime.DateTime) error
@@ -441,12 +441,12 @@ func (c *testServiceClientWithAuth) Echo(ctx context.Context) error {
 	return c.client.Echo(ctx, c.cookieToken)
 }
 
-func (c *testServiceClientWithAuth) GetPathParam(ctx context.Context, myPathParamArg string) error {
-	return c.client.GetPathParam(ctx, c.authHeader, myPathParamArg)
-}
-
 func (c *testServiceClientWithAuth) GetPathParamAlias(ctx context.Context, myPathParamArg StringAlias) error {
 	return c.client.GetPathParamAlias(ctx, c.authHeader, myPathParamArg)
+}
+
+func (c *testServiceClientWithAuth) GetPathParam(ctx context.Context, myPathParamArg string) error {
+	return c.client.GetPathParam(ctx, c.authHeader, myPathParamArg)
 }
 
 func (c *testServiceClientWithAuth) QueryParamList(ctx context.Context, myQueryParam1Arg []string) error {

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -30,6 +30,7 @@ type TestServiceClient interface {
 	QueryParamListString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListUuid(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []uuid.UUID) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -295,6 +296,36 @@ func (c *testServiceClient) PostPathParam(ctx context.Context, authHeader bearer
 	return *returnVal, nil
 }
 
+func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("PostSafeParams"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
+	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
+	requestParams = append(requestParams, httpclient.WithPathf("/safe/%s/%s", url.PathEscape(fmt.Sprint(myPathParam1Arg)), url.PathEscape(fmt.Sprint(myPathParam2Arg))))
+	requestParams = append(requestParams, httpclient.WithJSONRequest(myBodyParamArg))
+	requestParams = append(requestParams, httpclient.WithHeader("X-My-Header1-Abc", fmt.Sprint(myHeaderParam1Arg)))
+	if myHeaderParam2Arg != nil {
+		requestParams = append(requestParams, httpclient.WithHeader("X-My-Header2", fmt.Sprint(*myHeaderParam2Arg)))
+	}
+	queryParams := make(url.Values)
+	queryParams.Set("query1", fmt.Sprint(myQueryParam1Arg))
+	queryParams.Set("myQueryParam2", fmt.Sprint(myQueryParam2Arg))
+	queryParams.Set("myQueryParam3", fmt.Sprint(myQueryParam3Arg))
+	if myQueryParam4Arg != nil {
+		queryParams.Set("myQueryParam4", fmt.Sprint(*myQueryParam4Arg))
+	}
+	if myQueryParam5Arg != nil {
+		queryParams.Set("myQueryParam5", fmt.Sprint(*myQueryParam5Arg))
+	}
+	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
+	resp, err := c.client.Do(ctx, requestParams...)
+	if err != nil {
+		return err
+	}
+	_ = resp
+	return nil
+}
+
 func (c *testServiceClient) Bytes(ctx context.Context) (CustomObject, error) {
 	var defaultReturnVal CustomObject
 	var returnVal *CustomObject
@@ -387,6 +418,7 @@ type TestServiceClientWithAuth interface {
 	QueryParamListString(ctx context.Context, myQueryParam1Arg []string) error
 	QueryParamListUuid(ctx context.Context, myQueryParam1Arg []uuid.UUID) error
 	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
+	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -455,6 +487,10 @@ func (c *testServiceClientWithAuth) QueryParamListUuid(ctx context.Context, myQu
 
 func (c *testServiceClientWithAuth) PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error) {
 	return c.client.PostPathParam(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myHeaderParam1Arg, myHeaderParam2Arg)
+}
+
+func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+	return c.client.PostSafeParams(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 
 func (c *testServiceClientWithAuth) Bytes(ctx context.Context) (CustomObject, error) {

--- a/integration_test/testgenerated/server/clientparam_test.go
+++ b/integration_test/testgenerated/server/clientparam_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/witchcraft-go-server/rest"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -125,7 +125,7 @@ func TestBytes(t *testing.T) {
 	r := httprouter.New()
 	r.GET("/bytes", httprouter.Handle(func(rw http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		called = true
-		rest.WriteJSONResponse(rw, want, http.StatusOK)
+		httpserver.WriteJSONResponse(rw, want, http.StatusOK)
 	}))
 	server := httptest.NewServer(r)
 	defer server.Close()

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -1,4 +1,8 @@
 types:
+  imports:
+    Safe:
+      external:
+        java: com.palantir.logsafe.Safe
   definitions:
     default-package: api
     objects:
@@ -122,6 +126,50 @@ services:
             param-type: header
             param-id: X-My-Header2
         returns: CustomObject
+        #markers:
+        #              - Safe
+      postSafeParams:
+        http: POST /safe/{myPathParam1}/{myPathParam2}
+        auth: header
+        args:
+          myPathParam1:
+            type: string
+            markers:
+              - Safe
+          myPathParam2: boolean
+          myBodyParam:
+            type: CustomObject
+            param-type: body
+          myQueryParam1:
+            type: string
+            param-type: query
+            param-id: query1
+            markers:
+              - Safe
+          myQueryParam2:
+            type: string
+            param-type: query
+            markers:
+              - Safe
+          myQueryParam3:
+            type: double
+            param-type: query
+          myQueryParam4:
+            type: optional<safelong>
+            param-type: query
+          myQueryParam5:
+            type: optional<string>
+            param-type: query
+          myHeaderParam1:
+            type: safelong
+            param-type: header
+            param-id: X-My-Header1-Abc
+            markers:
+              - Safe
+          myHeaderParam2:
+            type: optional<uuid>
+            param-type: header
+            param-id: X-My-Header2
       bytes:
         http: GET /bytes
         returns: CustomObject

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -3,6 +3,9 @@ types:
     Safe:
       external:
         java: com.palantir.logsafe.Safe
+    OtherMarker:
+      external:
+        java: com.palantir.logsafe.OtherMarker
   definitions:
     default-package: api
     objects:
@@ -19,16 +22,16 @@ services:
       echo:
         http: GET /echo
         auth: "cookie:PALANTIR_TOKEN"
-      getPathParamAlias:
-        http: GET /path/alias/{myPathParam}
-        auth: header
-        args:
-          myPathParam: StringAlias
       getPathParam:
         http: GET /path/string/{myPathParam}
         auth: header
         args:
           myPathParam: string
+      getPathParamAlias:
+        http: GET /path/alias/{myPathParam}
+        auth: header
+        args:
+          myPathParam: StringAlias
       queryParamList:
         http: GET /pathNew
         auth: header
@@ -126,8 +129,6 @@ services:
             param-type: header
             param-id: X-My-Header2
         returns: CustomObject
-        #markers:
-        #              - Safe
       postSafeParams:
         http: POST /safe/{myPathParam1}/{myPathParam2}
         auth: header
@@ -154,6 +155,8 @@ services:
           myQueryParam3:
             type: double
             param-type: query
+            markers:
+              - OtherMarker
           myQueryParam4:
             type: optional<safelong>
             param-type: query

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -19,16 +19,16 @@ services:
       echo:
         http: GET /echo
         auth: "cookie:PALANTIR_TOKEN"
-      getPathParam:
-        http: GET /path/{myPathParam}
-        auth: header
-        args:
-          myPathParam: string
       getPathParamAlias:
         http: GET /path/alias/{myPathParam}
         auth: header
         args:
           myPathParam: StringAlias
+      getPathParam:
+        http: GET /path/string/{myPathParam}
+        auth: header
+        args:
+          myPathParam: string
       queryParamList:
         http: GET /pathNew
         auth: header

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -1,0 +1,174 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/palantir/pkg/bearertoken"
+	"github.com/palantir/pkg/datetime"
+	"github.com/palantir/pkg/rid"
+	"github.com/palantir/pkg/safelong"
+	"github.com/palantir/pkg/uuid"
+	"github.com/palantir/witchcraft-go-server/wrouter"
+	"github.com/palantir/witchcraft-go-server/wrouter/whttprouter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/palantir/conjure-go/v5/integration_test/testgenerated/server/api"
+)
+
+func TestSafeMarker(t *testing.T) {
+	router := wrouter.New(whttprouter.New())
+	err := api.RegisterRoutesTestService(router, testServerImpl{})
+	require.NoError(t, err)
+	called := false
+	router.AddRouteHandlerMiddleware(func(rw http.ResponseWriter, r *http.Request, reqVals wrouter.RequestVals, next wrouter.RouteRequestHandler) {
+		if reqVals.Spec.PathTemplate == "/safe/{myPathParam1}/{myPathParam2}" {
+			called = true
+
+			pathPerms := reqVals.ParamPerms.PathParamPerms()
+			assert.True(t, pathPerms.Safe("myPathParam1"))
+			assert.False(t, pathPerms.Safe("myPathParam2"))
+
+			headerPerms := reqVals.ParamPerms.HeaderParamPerms()
+			assert.True(t, headerPerms.Safe("X-My-Header1-Abc"))
+			assert.False(t, headerPerms.Safe("X-My-Header2"))
+
+			queryPerms := reqVals.ParamPerms.QueryParamPerms()
+			assert.True(t, queryPerms.Safe("query1"))
+			assert.True(t, queryPerms.Safe("myQueryParam2"))
+			assert.False(t, queryPerms.Safe("myQueryParam3"))
+		}
+		next(rw, r, reqVals)
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	long2 := safelong.SafeLong(2)
+	str := "abc"
+	id := uuid.NewUUID()
+	client := api.NewTestServiceClient(newHTTPClient(t, server.URL))
+	err = client.PostSafeParams(context.Background(),
+		"password",
+		"myPathParam1Arg",
+		true,
+		api.CustomObject{Data: []byte("hello world!")},
+		"myQueryParam1Arg",
+		"myQueryParam2Arg",
+		1,
+		&long2,
+		&str,
+		2,
+		&id)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+type testServerImpl struct{}
+
+func (t testServerImpl) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg api.CustomObject, myQueryParam1Arg string, myQueryParam2Arg string,
+	myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+	switch {
+	case authHeader == "":
+		return errors.New("empty authHeader")
+	case myPathParam1Arg == "":
+		return errors.New("empty myPathParam1Arg")
+	case myPathParam2Arg == false:
+		return errors.New("empty myPathParam2Arg")
+	case reflect.ValueOf(myBodyParamArg).IsZero():
+		return errors.New("empty myPathParam1Arg")
+	case myQueryParam1Arg == "":
+		return errors.New("empty myQueryParam1Arg")
+	case myQueryParam2Arg == "":
+		return errors.New("empty myQueryParam2Arg")
+	case myQueryParam3Arg == 0:
+		return errors.New("empty myQueryParam3Arg")
+	case myQueryParam4Arg == nil:
+		return errors.New("empty myQueryParam4Arg")
+	case myQueryParam5Arg == nil:
+		return errors.New("empty myQueryParam5Arg")
+	case myHeaderParam1Arg == 0:
+		return errors.New("empty myHeaderParam1Arg")
+	case myHeaderParam2Arg == nil:
+		return errors.New("empty myHeaderParam2Arg")
+	}
+	return nil
+}
+
+func (t testServerImpl) Echo(ctx context.Context, cookieToken bearertoken.Token) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) GetPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParamArg string) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) GetPathParamAlias(ctx context.Context, authHeader bearertoken.Token, myPathParamArg api.StringAlias) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamList(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListBoolean(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []bool) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListDateTime(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []datetime.DateTime) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListDouble(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []float64) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListInteger(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []int) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListRid(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []rid.ResourceIdentifier) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListSafeLong(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []safelong.SafeLong) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) QueryParamListUuid(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []uuid.UUID) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg api.CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (api.CustomObject, error) {
+	panic("implement me")
+}
+
+func (t testServerImpl) Bytes(ctx context.Context) (api.CustomObject, error) {
+	panic("implement me")
+}
+
+func (t testServerImpl) GetBinary(ctx context.Context) (io.ReadCloser, error) {
+	panic("implement me")
+}
+
+func (t testServerImpl) PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error) {
+	panic("implement me")
+}
+
+func (t testServerImpl) PutBinary(ctx context.Context, myBytesArg io.ReadCloser) error {
+	panic("implement me")
+}
+
+func (t testServerImpl) Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error {
+	panic("implement me")
+}

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -82,7 +82,7 @@ func (t testServerImpl) PostSafeParams(ctx context.Context, authHeader bearertok
 	case myPathParam2Arg == false:
 		return errors.New("empty myPathParam2Arg")
 	case reflect.ValueOf(myBodyParamArg).IsZero():
-		return errors.New("empty myPathParam1Arg")
+		return errors.New("empty myBodyParamArg")
 	case myQueryParam1Arg == "":
 		return errors.New("empty myQueryParam1Arg")
 	case myQueryParam2Arg == "":


### PR DESCRIPTION
## Before this PR
There was no way to enable safe logging on server parameters. See some discussion on https://github.com/palantir/conjure/issues/612.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Server route registration recognizes `com.palantir.logsafe.Safe` argument marker
==COMMIT_MSG==

Fixes #121 

## Possible downsides?
Hardcoding this is obviously brittle, though it matches what conjure-rust does and is probably worth it given this API is so widely used in the rest of the conjure ecosystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/138)
<!-- Reviewable:end -->
