### PR TITLE
aliaswriter: Initialize empty collections

### DIFF
--- a/changelog/@unreleased/pr-148.v2.yml
+++ b/changelog/@unreleased/pr-148.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'aliaswriter: Initialize empty collections'
+  links:
+  - https://github.com/palantir/conjure-go/pull/148

--- a/conjure-go-verifier/conjure/verification/types/aliases.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/aliases.conjure.go
@@ -90,9 +90,49 @@ func (a *DateTimeAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) 
 type DoubleAliasExample float64
 type IntegerAliasExample int
 type ListAnyAliasExample []interface{}
+
+func (a ListAnyAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]interface{}, 0)
+	}
+	return safejson.Marshal([]interface{}(a))
+}
+
+func (a *ListAnyAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListAnyAliasExample []interface{}
+	if err := safejson.Unmarshal(data, &rawListAnyAliasExample); err != nil {
+		return err
+	}
+	if rawListAnyAliasExample == nil {
+		*a = make([]interface{}, 0)
+	} else {
+		*a = ListAnyAliasExample(rawListAnyAliasExample)
+	}
+	return nil
+}
+
+func (a ListAnyAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListAnyAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListBearerTokenAliasExample []bearertoken.Token
 
 func (a ListBearerTokenAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]bearertoken.Token, 0)
+	}
 	return safejson.Marshal([]bearertoken.Token(a))
 }
 
@@ -101,7 +141,11 @@ func (a *ListBearerTokenAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawListBearerTokenAliasExample); err != nil {
 		return err
 	}
-	*a = ListBearerTokenAliasExample(rawListBearerTokenAliasExample)
+	if rawListBearerTokenAliasExample == nil {
+		*a = make([]bearertoken.Token, 0)
+	} else {
+		*a = ListBearerTokenAliasExample(rawListBearerTokenAliasExample)
+	}
 	return nil
 }
 
@@ -122,10 +166,87 @@ func (a *ListBearerTokenAliasExample) UnmarshalYAML(unmarshal func(interface{}) 
 }
 
 type ListBinaryAliasExample [][]byte
+
+func (a ListBinaryAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([][]byte, 0)
+	}
+	return safejson.Marshal([][]byte(a))
+}
+
+func (a *ListBinaryAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListBinaryAliasExample [][]byte
+	if err := safejson.Unmarshal(data, &rawListBinaryAliasExample); err != nil {
+		return err
+	}
+	if rawListBinaryAliasExample == nil {
+		*a = make([][]byte, 0)
+	} else {
+		*a = ListBinaryAliasExample(rawListBinaryAliasExample)
+	}
+	return nil
+}
+
+func (a ListBinaryAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListBinaryAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListBooleanAliasExample []bool
+
+func (a ListBooleanAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]bool, 0)
+	}
+	return safejson.Marshal([]bool(a))
+}
+
+func (a *ListBooleanAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListBooleanAliasExample []bool
+	if err := safejson.Unmarshal(data, &rawListBooleanAliasExample); err != nil {
+		return err
+	}
+	if rawListBooleanAliasExample == nil {
+		*a = make([]bool, 0)
+	} else {
+		*a = ListBooleanAliasExample(rawListBooleanAliasExample)
+	}
+	return nil
+}
+
+func (a ListBooleanAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListBooleanAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListDateTimeAliasExample []datetime.DateTime
 
 func (a ListDateTimeAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]datetime.DateTime, 0)
+	}
 	return safejson.Marshal([]datetime.DateTime(a))
 }
 
@@ -134,7 +255,11 @@ func (a *ListDateTimeAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawListDateTimeAliasExample); err != nil {
 		return err
 	}
-	*a = ListDateTimeAliasExample(rawListDateTimeAliasExample)
+	if rawListDateTimeAliasExample == nil {
+		*a = make([]datetime.DateTime, 0)
+	} else {
+		*a = ListDateTimeAliasExample(rawListDateTimeAliasExample)
+	}
 	return nil
 }
 
@@ -155,11 +280,125 @@ func (a *ListDateTimeAliasExample) UnmarshalYAML(unmarshal func(interface{}) err
 }
 
 type ListDoubleAliasExample []float64
+
+func (a ListDoubleAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]float64, 0)
+	}
+	return safejson.Marshal([]float64(a))
+}
+
+func (a *ListDoubleAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListDoubleAliasExample []float64
+	if err := safejson.Unmarshal(data, &rawListDoubleAliasExample); err != nil {
+		return err
+	}
+	if rawListDoubleAliasExample == nil {
+		*a = make([]float64, 0)
+	} else {
+		*a = ListDoubleAliasExample(rawListDoubleAliasExample)
+	}
+	return nil
+}
+
+func (a ListDoubleAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListDoubleAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListIntegerAliasExample []int
+
+func (a ListIntegerAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]int, 0)
+	}
+	return safejson.Marshal([]int(a))
+}
+
+func (a *ListIntegerAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListIntegerAliasExample []int
+	if err := safejson.Unmarshal(data, &rawListIntegerAliasExample); err != nil {
+		return err
+	}
+	if rawListIntegerAliasExample == nil {
+		*a = make([]int, 0)
+	} else {
+		*a = ListIntegerAliasExample(rawListIntegerAliasExample)
+	}
+	return nil
+}
+
+func (a ListIntegerAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListIntegerAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListOptionalAnyAliasExample []*interface{}
+
+func (a ListOptionalAnyAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]*interface{}, 0)
+	}
+	return safejson.Marshal([]*interface{}(a))
+}
+
+func (a *ListOptionalAnyAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListOptionalAnyAliasExample []*interface{}
+	if err := safejson.Unmarshal(data, &rawListOptionalAnyAliasExample); err != nil {
+		return err
+	}
+	if rawListOptionalAnyAliasExample == nil {
+		*a = make([]*interface{}, 0)
+	} else {
+		*a = ListOptionalAnyAliasExample(rawListOptionalAnyAliasExample)
+	}
+	return nil
+}
+
+func (a ListOptionalAnyAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListOptionalAnyAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListRidAliasExample []rid.ResourceIdentifier
 
 func (a ListRidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]rid.ResourceIdentifier, 0)
+	}
 	return safejson.Marshal([]rid.ResourceIdentifier(a))
 }
 
@@ -168,7 +407,11 @@ func (a *ListRidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawListRidAliasExample); err != nil {
 		return err
 	}
-	*a = ListRidAliasExample(rawListRidAliasExample)
+	if rawListRidAliasExample == nil {
+		*a = make([]rid.ResourceIdentifier, 0)
+	} else {
+		*a = ListRidAliasExample(rawListRidAliasExample)
+	}
 	return nil
 }
 
@@ -191,6 +434,9 @@ func (a *ListRidAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) e
 type ListSafeLongAliasExample []safelong.SafeLong
 
 func (a ListSafeLongAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]safelong.SafeLong, 0)
+	}
 	return safejson.Marshal([]safelong.SafeLong(a))
 }
 
@@ -199,7 +445,11 @@ func (a *ListSafeLongAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawListSafeLongAliasExample); err != nil {
 		return err
 	}
-	*a = ListSafeLongAliasExample(rawListSafeLongAliasExample)
+	if rawListSafeLongAliasExample == nil {
+		*a = make([]safelong.SafeLong, 0)
+	} else {
+		*a = ListSafeLongAliasExample(rawListSafeLongAliasExample)
+	}
 	return nil
 }
 
@@ -220,9 +470,49 @@ func (a *ListSafeLongAliasExample) UnmarshalYAML(unmarshal func(interface{}) err
 }
 
 type ListStringAliasExample []string
+
+func (a ListStringAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]string, 0)
+	}
+	return safejson.Marshal([]string(a))
+}
+
+func (a *ListStringAliasExample) UnmarshalJSON(data []byte) error {
+	var rawListStringAliasExample []string
+	if err := safejson.Unmarshal(data, &rawListStringAliasExample); err != nil {
+		return err
+	}
+	if rawListStringAliasExample == nil {
+		*a = make([]string, 0)
+	} else {
+		*a = ListStringAliasExample(rawListStringAliasExample)
+	}
+	return nil
+}
+
+func (a ListStringAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListStringAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type ListUuidAliasExample []uuid.UUID
 
 func (a ListUuidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]uuid.UUID, 0)
+	}
 	return safejson.Marshal([]uuid.UUID(a))
 }
 
@@ -231,7 +521,11 @@ func (a *ListUuidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawListUuidAliasExample); err != nil {
 		return err
 	}
-	*a = ListUuidAliasExample(rawListUuidAliasExample)
+	if rawListUuidAliasExample == nil {
+		*a = make([]uuid.UUID, 0)
+	} else {
+		*a = ListUuidAliasExample(rawListUuidAliasExample)
+	}
 	return nil
 }
 
@@ -254,6 +548,9 @@ func (a *ListUuidAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) 
 type MapBearerTokenAliasExample map[bearertoken.Token]bool
 
 func (a MapBearerTokenAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[bearertoken.Token]bool, 0)
+	}
 	return safejson.Marshal(map[bearertoken.Token]bool(a))
 }
 
@@ -262,7 +559,11 @@ func (a *MapBearerTokenAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapBearerTokenAliasExample); err != nil {
 		return err
 	}
-	*a = MapBearerTokenAliasExample(rawMapBearerTokenAliasExample)
+	if rawMapBearerTokenAliasExample == nil {
+		*a = make(map[bearertoken.Token]bool, 0)
+	} else {
+		*a = MapBearerTokenAliasExample(rawMapBearerTokenAliasExample)
+	}
 	return nil
 }
 
@@ -285,6 +586,9 @@ func (a *MapBearerTokenAliasExample) UnmarshalYAML(unmarshal func(interface{}) e
 type MapBinaryAliasExample map[binary.Binary]bool
 
 func (a MapBinaryAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[binary.Binary]bool, 0)
+	}
 	return safejson.Marshal(map[binary.Binary]bool(a))
 }
 
@@ -293,7 +597,11 @@ func (a *MapBinaryAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapBinaryAliasExample); err != nil {
 		return err
 	}
-	*a = MapBinaryAliasExample(rawMapBinaryAliasExample)
+	if rawMapBinaryAliasExample == nil {
+		*a = make(map[binary.Binary]bool, 0)
+	} else {
+		*a = MapBinaryAliasExample(rawMapBinaryAliasExample)
+	}
 	return nil
 }
 
@@ -316,6 +624,9 @@ func (a *MapBinaryAliasExample) UnmarshalYAML(unmarshal func(interface{}) error)
 type MapBooleanAliasExample map[boolean.Boolean]bool
 
 func (a MapBooleanAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[boolean.Boolean]bool, 0)
+	}
 	return safejson.Marshal(map[boolean.Boolean]bool(a))
 }
 
@@ -324,7 +635,11 @@ func (a *MapBooleanAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapBooleanAliasExample); err != nil {
 		return err
 	}
-	*a = MapBooleanAliasExample(rawMapBooleanAliasExample)
+	if rawMapBooleanAliasExample == nil {
+		*a = make(map[boolean.Boolean]bool, 0)
+	} else {
+		*a = MapBooleanAliasExample(rawMapBooleanAliasExample)
+	}
 	return nil
 }
 
@@ -347,6 +662,9 @@ func (a *MapBooleanAliasExample) UnmarshalYAML(unmarshal func(interface{}) error
 type MapDateTimeAliasExample map[datetime.DateTime]bool
 
 func (a MapDateTimeAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[datetime.DateTime]bool, 0)
+	}
 	return safejson.Marshal(map[datetime.DateTime]bool(a))
 }
 
@@ -355,7 +673,11 @@ func (a *MapDateTimeAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapDateTimeAliasExample); err != nil {
 		return err
 	}
-	*a = MapDateTimeAliasExample(rawMapDateTimeAliasExample)
+	if rawMapDateTimeAliasExample == nil {
+		*a = make(map[datetime.DateTime]bool, 0)
+	} else {
+		*a = MapDateTimeAliasExample(rawMapDateTimeAliasExample)
+	}
 	return nil
 }
 
@@ -376,9 +698,49 @@ func (a *MapDateTimeAliasExample) UnmarshalYAML(unmarshal func(interface{}) erro
 }
 
 type MapDoubleAliasExample map[float64]bool
+
+func (a MapDoubleAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[float64]bool, 0)
+	}
+	return safejson.Marshal(map[float64]bool(a))
+}
+
+func (a *MapDoubleAliasExample) UnmarshalJSON(data []byte) error {
+	var rawMapDoubleAliasExample map[float64]bool
+	if err := safejson.Unmarshal(data, &rawMapDoubleAliasExample); err != nil {
+		return err
+	}
+	if rawMapDoubleAliasExample == nil {
+		*a = make(map[float64]bool, 0)
+	} else {
+		*a = MapDoubleAliasExample(rawMapDoubleAliasExample)
+	}
+	return nil
+}
+
+func (a MapDoubleAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *MapDoubleAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type MapEnumExampleAlias map[EnumExample]string
 
 func (a MapEnumExampleAlias) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[EnumExample]string, 0)
+	}
 	return safejson.Marshal(map[EnumExample]string(a))
 }
 
@@ -387,7 +749,11 @@ func (a *MapEnumExampleAlias) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapEnumExampleAlias); err != nil {
 		return err
 	}
-	*a = MapEnumExampleAlias(rawMapEnumExampleAlias)
+	if rawMapEnumExampleAlias == nil {
+		*a = make(map[EnumExample]string, 0)
+	} else {
+		*a = MapEnumExampleAlias(rawMapEnumExampleAlias)
+	}
 	return nil
 }
 
@@ -408,9 +774,49 @@ func (a *MapEnumExampleAlias) UnmarshalYAML(unmarshal func(interface{}) error) e
 }
 
 type MapIntegerAliasExample map[int]bool
+
+func (a MapIntegerAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[int]bool, 0)
+	}
+	return safejson.Marshal(map[int]bool(a))
+}
+
+func (a *MapIntegerAliasExample) UnmarshalJSON(data []byte) error {
+	var rawMapIntegerAliasExample map[int]bool
+	if err := safejson.Unmarshal(data, &rawMapIntegerAliasExample); err != nil {
+		return err
+	}
+	if rawMapIntegerAliasExample == nil {
+		*a = make(map[int]bool, 0)
+	} else {
+		*a = MapIntegerAliasExample(rawMapIntegerAliasExample)
+	}
+	return nil
+}
+
+func (a MapIntegerAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *MapIntegerAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type MapRidAliasExample map[rid.ResourceIdentifier]bool
 
 func (a MapRidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[rid.ResourceIdentifier]bool, 0)
+	}
 	return safejson.Marshal(map[rid.ResourceIdentifier]bool(a))
 }
 
@@ -419,7 +825,11 @@ func (a *MapRidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapRidAliasExample); err != nil {
 		return err
 	}
-	*a = MapRidAliasExample(rawMapRidAliasExample)
+	if rawMapRidAliasExample == nil {
+		*a = make(map[rid.ResourceIdentifier]bool, 0)
+	} else {
+		*a = MapRidAliasExample(rawMapRidAliasExample)
+	}
 	return nil
 }
 
@@ -442,6 +852,9 @@ func (a *MapRidAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) er
 type MapSafeLongAliasExample map[safelong.SafeLong]bool
 
 func (a MapSafeLongAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[safelong.SafeLong]bool, 0)
+	}
 	return safejson.Marshal(map[safelong.SafeLong]bool(a))
 }
 
@@ -450,7 +863,11 @@ func (a *MapSafeLongAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapSafeLongAliasExample); err != nil {
 		return err
 	}
-	*a = MapSafeLongAliasExample(rawMapSafeLongAliasExample)
+	if rawMapSafeLongAliasExample == nil {
+		*a = make(map[safelong.SafeLong]bool, 0)
+	} else {
+		*a = MapSafeLongAliasExample(rawMapSafeLongAliasExample)
+	}
 	return nil
 }
 
@@ -471,9 +888,49 @@ func (a *MapSafeLongAliasExample) UnmarshalYAML(unmarshal func(interface{}) erro
 }
 
 type MapStringAliasExample map[string]bool
+
+func (a MapStringAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[string]bool, 0)
+	}
+	return safejson.Marshal(map[string]bool(a))
+}
+
+func (a *MapStringAliasExample) UnmarshalJSON(data []byte) error {
+	var rawMapStringAliasExample map[string]bool
+	if err := safejson.Unmarshal(data, &rawMapStringAliasExample); err != nil {
+		return err
+	}
+	if rawMapStringAliasExample == nil {
+		*a = make(map[string]bool, 0)
+	} else {
+		*a = MapStringAliasExample(rawMapStringAliasExample)
+	}
+	return nil
+}
+
+func (a MapStringAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *MapStringAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type MapUuidAliasExample map[uuid.UUID]bool
 
 func (a MapUuidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[uuid.UUID]bool, 0)
+	}
 	return safejson.Marshal(map[uuid.UUID]bool(a))
 }
 
@@ -482,7 +939,11 @@ func (a *MapUuidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapUuidAliasExample); err != nil {
 		return err
 	}
-	*a = MapUuidAliasExample(rawMapUuidAliasExample)
+	if rawMapUuidAliasExample == nil {
+		*a = make(map[uuid.UUID]bool, 0)
+	} else {
+		*a = MapUuidAliasExample(rawMapUuidAliasExample)
+	}
 	return nil
 }
 
@@ -973,9 +1434,49 @@ func (a *SafeLongAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) 
 }
 
 type SetAnyAliasExample []interface{}
+
+func (a SetAnyAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]interface{}, 0)
+	}
+	return safejson.Marshal([]interface{}(a))
+}
+
+func (a *SetAnyAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetAnyAliasExample []interface{}
+	if err := safejson.Unmarshal(data, &rawSetAnyAliasExample); err != nil {
+		return err
+	}
+	if rawSetAnyAliasExample == nil {
+		*a = make([]interface{}, 0)
+	} else {
+		*a = SetAnyAliasExample(rawSetAnyAliasExample)
+	}
+	return nil
+}
+
+func (a SetAnyAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetAnyAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetBearerTokenAliasExample []bearertoken.Token
 
 func (a SetBearerTokenAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]bearertoken.Token, 0)
+	}
 	return safejson.Marshal([]bearertoken.Token(a))
 }
 
@@ -984,7 +1485,11 @@ func (a *SetBearerTokenAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawSetBearerTokenAliasExample); err != nil {
 		return err
 	}
-	*a = SetBearerTokenAliasExample(rawSetBearerTokenAliasExample)
+	if rawSetBearerTokenAliasExample == nil {
+		*a = make([]bearertoken.Token, 0)
+	} else {
+		*a = SetBearerTokenAliasExample(rawSetBearerTokenAliasExample)
+	}
 	return nil
 }
 
@@ -1005,10 +1510,87 @@ func (a *SetBearerTokenAliasExample) UnmarshalYAML(unmarshal func(interface{}) e
 }
 
 type SetBinaryAliasExample [][]byte
+
+func (a SetBinaryAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([][]byte, 0)
+	}
+	return safejson.Marshal([][]byte(a))
+}
+
+func (a *SetBinaryAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetBinaryAliasExample [][]byte
+	if err := safejson.Unmarshal(data, &rawSetBinaryAliasExample); err != nil {
+		return err
+	}
+	if rawSetBinaryAliasExample == nil {
+		*a = make([][]byte, 0)
+	} else {
+		*a = SetBinaryAliasExample(rawSetBinaryAliasExample)
+	}
+	return nil
+}
+
+func (a SetBinaryAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetBinaryAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetBooleanAliasExample []bool
+
+func (a SetBooleanAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]bool, 0)
+	}
+	return safejson.Marshal([]bool(a))
+}
+
+func (a *SetBooleanAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetBooleanAliasExample []bool
+	if err := safejson.Unmarshal(data, &rawSetBooleanAliasExample); err != nil {
+		return err
+	}
+	if rawSetBooleanAliasExample == nil {
+		*a = make([]bool, 0)
+	} else {
+		*a = SetBooleanAliasExample(rawSetBooleanAliasExample)
+	}
+	return nil
+}
+
+func (a SetBooleanAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetBooleanAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetDateTimeAliasExample []datetime.DateTime
 
 func (a SetDateTimeAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]datetime.DateTime, 0)
+	}
 	return safejson.Marshal([]datetime.DateTime(a))
 }
 
@@ -1017,7 +1599,11 @@ func (a *SetDateTimeAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawSetDateTimeAliasExample); err != nil {
 		return err
 	}
-	*a = SetDateTimeAliasExample(rawSetDateTimeAliasExample)
+	if rawSetDateTimeAliasExample == nil {
+		*a = make([]datetime.DateTime, 0)
+	} else {
+		*a = SetDateTimeAliasExample(rawSetDateTimeAliasExample)
+	}
 	return nil
 }
 
@@ -1038,11 +1624,125 @@ func (a *SetDateTimeAliasExample) UnmarshalYAML(unmarshal func(interface{}) erro
 }
 
 type SetDoubleAliasExample []float64
+
+func (a SetDoubleAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]float64, 0)
+	}
+	return safejson.Marshal([]float64(a))
+}
+
+func (a *SetDoubleAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetDoubleAliasExample []float64
+	if err := safejson.Unmarshal(data, &rawSetDoubleAliasExample); err != nil {
+		return err
+	}
+	if rawSetDoubleAliasExample == nil {
+		*a = make([]float64, 0)
+	} else {
+		*a = SetDoubleAliasExample(rawSetDoubleAliasExample)
+	}
+	return nil
+}
+
+func (a SetDoubleAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetDoubleAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetIntegerAliasExample []int
+
+func (a SetIntegerAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]int, 0)
+	}
+	return safejson.Marshal([]int(a))
+}
+
+func (a *SetIntegerAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetIntegerAliasExample []int
+	if err := safejson.Unmarshal(data, &rawSetIntegerAliasExample); err != nil {
+		return err
+	}
+	if rawSetIntegerAliasExample == nil {
+		*a = make([]int, 0)
+	} else {
+		*a = SetIntegerAliasExample(rawSetIntegerAliasExample)
+	}
+	return nil
+}
+
+func (a SetIntegerAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetIntegerAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetOptionalAnyAliasExample []*interface{}
+
+func (a SetOptionalAnyAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]*interface{}, 0)
+	}
+	return safejson.Marshal([]*interface{}(a))
+}
+
+func (a *SetOptionalAnyAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetOptionalAnyAliasExample []*interface{}
+	if err := safejson.Unmarshal(data, &rawSetOptionalAnyAliasExample); err != nil {
+		return err
+	}
+	if rawSetOptionalAnyAliasExample == nil {
+		*a = make([]*interface{}, 0)
+	} else {
+		*a = SetOptionalAnyAliasExample(rawSetOptionalAnyAliasExample)
+	}
+	return nil
+}
+
+func (a SetOptionalAnyAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetOptionalAnyAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetRidAliasExample []rid.ResourceIdentifier
 
 func (a SetRidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]rid.ResourceIdentifier, 0)
+	}
 	return safejson.Marshal([]rid.ResourceIdentifier(a))
 }
 
@@ -1051,7 +1751,11 @@ func (a *SetRidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawSetRidAliasExample); err != nil {
 		return err
 	}
-	*a = SetRidAliasExample(rawSetRidAliasExample)
+	if rawSetRidAliasExample == nil {
+		*a = make([]rid.ResourceIdentifier, 0)
+	} else {
+		*a = SetRidAliasExample(rawSetRidAliasExample)
+	}
 	return nil
 }
 
@@ -1074,6 +1778,9 @@ func (a *SetRidAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) er
 type SetSafeLongAliasExample []safelong.SafeLong
 
 func (a SetSafeLongAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]safelong.SafeLong, 0)
+	}
 	return safejson.Marshal([]safelong.SafeLong(a))
 }
 
@@ -1082,7 +1789,11 @@ func (a *SetSafeLongAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawSetSafeLongAliasExample); err != nil {
 		return err
 	}
-	*a = SetSafeLongAliasExample(rawSetSafeLongAliasExample)
+	if rawSetSafeLongAliasExample == nil {
+		*a = make([]safelong.SafeLong, 0)
+	} else {
+		*a = SetSafeLongAliasExample(rawSetSafeLongAliasExample)
+	}
 	return nil
 }
 
@@ -1103,9 +1814,49 @@ func (a *SetSafeLongAliasExample) UnmarshalYAML(unmarshal func(interface{}) erro
 }
 
 type SetStringAliasExample []string
+
+func (a SetStringAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]string, 0)
+	}
+	return safejson.Marshal([]string(a))
+}
+
+func (a *SetStringAliasExample) UnmarshalJSON(data []byte) error {
+	var rawSetStringAliasExample []string
+	if err := safejson.Unmarshal(data, &rawSetStringAliasExample); err != nil {
+		return err
+	}
+	if rawSetStringAliasExample == nil {
+		*a = make([]string, 0)
+	} else {
+		*a = SetStringAliasExample(rawSetStringAliasExample)
+	}
+	return nil
+}
+
+func (a SetStringAliasExample) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *SetStringAliasExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type SetUuidAliasExample []uuid.UUID
 
 func (a SetUuidAliasExample) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]uuid.UUID, 0)
+	}
 	return safejson.Marshal([]uuid.UUID(a))
 }
 
@@ -1114,7 +1865,11 @@ func (a *SetUuidAliasExample) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawSetUuidAliasExample); err != nil {
 		return err
 	}
-	*a = SetUuidAliasExample(rawSetUuidAliasExample)
+	if rawSetUuidAliasExample == nil {
+		*a = make([]uuid.UUID, 0)
+	} else {
+		*a = SetUuidAliasExample(rawSetUuidAliasExample)
+	}
 	return nil
 }
 

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -524,6 +524,9 @@ func (a *ObjectAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type MapAlias map[string]Status
 
 func (a MapAlias) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[string]Status, 0)
+	}
 	return safejson.Marshal(map[string]Status(a))
 }
 
@@ -532,7 +535,11 @@ func (a *MapAlias) UnmarshalJSON(data []byte) error {
 	if err := safejson.Unmarshal(data, &rawMapAlias); err != nil {
 		return err
 	}
-	*a = MapAlias(rawMapAlias)
+	if rawMapAlias == nil {
+		*a = make(map[string]Status, 0)
+	} else {
+		*a = MapAlias(rawMapAlias)
+	}
 	return nil
 }
 

--- a/integration_test/testgenerated/objects/api/aliases.conjure.go
+++ b/integration_test/testgenerated/objects/api/aliases.conjure.go
@@ -10,6 +10,82 @@ import (
 )
 
 type BinaryAlias []byte
+type ListAlias []string
+
+func (a ListAlias) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make([]string, 0)
+	}
+	return safejson.Marshal([]string(a))
+}
+
+func (a *ListAlias) UnmarshalJSON(data []byte) error {
+	var rawListAlias []string
+	if err := safejson.Unmarshal(data, &rawListAlias); err != nil {
+		return err
+	}
+	if rawListAlias == nil {
+		*a = make([]string, 0)
+	} else {
+		*a = ListAlias(rawListAlias)
+	}
+	return nil
+}
+
+func (a ListAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *ListAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
+type MapAlias map[string]string
+
+func (a MapAlias) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		a = make(map[string]string, 0)
+	}
+	return safejson.Marshal(map[string]string(a))
+}
+
+func (a *MapAlias) UnmarshalJSON(data []byte) error {
+	var rawMapAlias map[string]string
+	if err := safejson.Unmarshal(data, &rawMapAlias); err != nil {
+		return err
+	}
+	if rawMapAlias == nil {
+		*a = make(map[string]string, 0)
+	} else {
+		*a = MapAlias(rawMapAlias)
+	}
+	return nil
+}
+
+func (a MapAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *MapAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type OptionalUuidAlias struct {
 	Value *uuid.UUID
 }

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -21,6 +21,10 @@ types:
       ExampleUuid:
         fields:
           uid: uuid
+      ListAlias:
+        alias: list<string>
+      MapAlias:
+        alias: map<string, string>
       OptionalUuidAlias:
         alias: optional<uuid>
       RidAlias:

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -304,3 +304,44 @@ func TestEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectionAliases(t *testing.T) {
+	t.Run("nonempty list", func(t *testing.T) {
+		list1 := api.ListAlias{"foo", "bar"}
+		out1, err := json.Marshal(list1)
+		require.NoError(t, err)
+		assert.JSONEq(t, `["foo","bar"]`, string(out1))
+		var unmarshal1 api.ListAlias
+		err = json.Unmarshal(out1, &unmarshal1)
+		assert.Equal(t, list1, unmarshal1)
+	})
+	t.Run("empty list", func(t *testing.T) {
+		list1 := api.ListAlias(nil)
+		out1, err := json.Marshal(list1)
+		require.NoError(t, err)
+		assert.JSONEq(t, `[]`, string(out1))
+
+		var unmarshal1 api.ListAlias
+		err = json.Unmarshal([]byte("null"), &unmarshal1)
+		assert.Equal(t, api.ListAlias{}, unmarshal1)
+	})
+	t.Run("nonempty map", func(t *testing.T) {
+		map1 := api.MapAlias{"foo": "bar"}
+		out1, err := json.Marshal(map1)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"foo":"bar"}`, string(out1))
+		var unmarshal1 api.MapAlias
+		err = json.Unmarshal(out1, &unmarshal1)
+		assert.Equal(t, map1, unmarshal1)
+	})
+	t.Run("empty map", func(t *testing.T) {
+		map1 := api.MapAlias(nil)
+		out1, err := json.Marshal(map1)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{}`, string(out1))
+
+		var unmarshal1 api.MapAlias
+		err = json.Unmarshal([]byte("null"), &unmarshal1)
+		assert.Equal(t, api.MapAlias{}, unmarshal1)
+	})
+}


### PR DESCRIPTION
The conjure spec says that empty collections should be initialized to their zero-element value. 

Fixes https://github.com/palantir/conjure-go/issues/73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/148)
<!-- Reviewable:end -->
