### PR TITLE
Improvement: Generate IsErrorType helpers for conjure errors

### DIFF
--- a/changelog/@unreleased/pr-151.v2.yml
+++ b/changelog/@unreleased/pr-151.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generate IsErrorType helpers for conjure errors
+  links:
+  - https://github.com/palantir/conjure-go/pull/151

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2163,6 +2163,7 @@ import (
 	"github.com/palantir/pkg/safejson"
 	"github.com/palantir/pkg/safeyaml"
 	"github.com/palantir/pkg/uuid"
+	werror "github.com/palantir/witchcraft-go-error"
 )
 
 type myNotFound struct {
@@ -2200,6 +2201,15 @@ func NewMyNotFound(safeArgAArg api.SimpleObject, safeArgBArg int, unsafeArgAArg 
 type MyNotFound struct {
 	errorInstanceID uuid.UUID
 	myNotFound
+}
+
+// IsMyNotFound returns true if err is an instance of MyNotFound.
+func IsMyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := werror.RootCause(err).(*MyNotFound)
+	return ok
 }
 
 func (e *MyNotFound) Error() string {

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -34,6 +34,7 @@ const (
 	errorReceiverName    = "e"
 	errorInstanceIDField = "errorInstanceID"
 	errorInstanceIDParam = "errorInstanceId"
+	errVarName           = "err"
 )
 
 const (
@@ -134,6 +135,7 @@ func astForError(errorDefinition spec.ErrorDefinition, info types.PkgInfo) ([]as
 		),
 	)
 	for _, f := range []errorDeclFunc{
+		astIsErrorTypeFunc,
 		astErrorErrorMethod,
 		astErrorCodeMethod,
 		astErrorNameMethod,
@@ -611,5 +613,62 @@ func astErrorInitFunc(errorDefinitions []spec.ErrorDefinition, info types.PkgInf
 	return &decl.Function{
 		Name: "init",
 		Body: stmts,
+	}
+}
+
+// astIsErrorTypeFunc generates a helper func that checks whether an error is of the error type:
+//
+// func IsMyNotFound(err error) bool {
+//	   if err == nil {
+//		   return false
+//	   }
+//	   _, ok := werror.RootCause(err).(*MyNotFound)
+//	   return ok
+// }
+func astIsErrorTypeFunc(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
+	info.SetImports("werror", "github.com/palantir/witchcraft-go-error")
+	return &decl.Function{
+		Name: "Is" + errorDefinition.ErrorName.Name,
+		FuncType: expression.FuncType{
+			Params: []*expression.FuncParam{
+				{
+					Names: []string{"err"},
+					Type:  expression.ErrorType,
+				},
+			},
+			ReturnTypes: []expression.Type{expression.BoolType},
+		},
+		Comment: fmt.Sprintf("Is%s returns true if err is an instance of %s.",
+			errorDefinition.ErrorName.Name,
+			errorDefinition.ErrorName.Name,
+		),
+		Body: []astgen.ASTStmt{
+			&statement.If{
+				Cond: &expression.Binary{
+					LHS: expression.VariableVal(errVarName),
+					Op:  token.EQL,
+					RHS: expression.Nil,
+				},
+				Body: []astgen.ASTStmt{
+					&statement.Return{
+						Values: []astgen.ASTExpr{
+							expression.VariableVal("false"),
+						},
+					},
+				},
+			},
+			&statement.Assignment{
+				LHS: []astgen.ASTExpr{
+					expression.VariableVal("_"),
+					expression.VariableVal("ok"),
+				},
+				Tok: token.DEFINE,
+				RHS: &expression.TypeAssert{
+					Receiver: expression.NewCallFunction("werror", "RootCause", expression.VariableVal(errVarName)),
+					Type:     expression.Type(fmt.Sprintf("*%s", errorDefinition.ErrorName.Name)),
+				},
+			},
+			&statement.Return{Values: []astgen.ASTExpr{expression.VariableVal("ok")}},
+		},
 	}
 }

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -632,7 +632,7 @@ func astIsErrorTypeFunc(errorDefinition spec.ErrorDefinition, info types.PkgInfo
 		FuncType: expression.FuncType{
 			Params: []*expression.FuncParam{
 				{
-					Names: []string{"err"},
+					Names: []string{errVarName},
 					Type:  expression.ErrorType,
 				},
 			},

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -11,6 +11,7 @@ import (
 	"github.com/palantir/pkg/safejson"
 	"github.com/palantir/pkg/safeyaml"
 	"github.com/palantir/pkg/uuid"
+	werror "github.com/palantir/witchcraft-go-error"
 )
 
 type myInternal struct {
@@ -73,6 +74,15 @@ func NewMyInternal(safeArgAArg Basic, safeArgBArg []int, typeArg string, unsafeA
 type MyInternal struct {
 	errorInstanceID uuid.UUID
 	myInternal
+}
+
+// IsMyInternal returns true if err is an instance of MyInternal.
+func IsMyInternal(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := werror.RootCause(err).(*MyInternal)
+	return ok
 }
 
 func (e *MyInternal) Error() string {
@@ -190,6 +200,15 @@ func NewMyNotFound(safeArgAArg Basic, safeArgBArg []int, typeArg string, unsafeA
 type MyNotFound struct {
 	errorInstanceID uuid.UUID
 	myNotFound
+}
+
+// IsMyNotFound returns true if err is an instance of MyNotFound.
+func IsMyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := werror.RootCause(err).(*MyNotFound)
+	return ok
 }
 
 func (e *MyNotFound) Error() string {

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -150,7 +150,7 @@ func TestError_IsErrorType(t *testing.T) {
 	testErrorNotFound := api.NewMyNotFound(api.Basic{}, []int{}, "", "", nil)
 
 	assert.True(t, api.IsMyInternal(testErrorInternal))
-	assert.False(t, api.IsMyNotFound(testErrorInternal))
+	assert.False(t, api.IsMyInternal(testErrorNotFound))
 	assert.True(t, api.IsMyNotFound(testErrorNotFound))
 	assert.False(t, api.IsMyNotFound(testErrorInternal))
 

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -145,3 +145,16 @@ func TestError_Init(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, myInternalErr, testErrorInternal)
 }
+
+func TestError_IsErrorType(t *testing.T) {
+	testErrorNotFound := api.NewMyNotFound(api.Basic{}, []int{}, "", "", nil)
+
+	assert.True(t, api.IsMyInternal(testErrorInternal))
+	assert.False(t, api.IsMyNotFound(testErrorInternal))
+	assert.True(t, api.IsMyNotFound(testErrorNotFound))
+	assert.False(t, api.IsMyNotFound(testErrorInternal))
+
+	assert.False(t, api.IsMyInternal(nil))
+	assert.False(t, api.IsMyInternal(fmt.Errorf("error")))
+	assert.False(t, api.IsMyInternal(errors.NewInternal()))
+}


### PR DESCRIPTION
==COMMIT_MSG==
Generate IsErrorType helpers for conjure errors
==COMMIT_MSG==

Fixes #141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/151)
<!-- Reviewable:end -->
