### PR TITLE
Add IsUnknown() and Values() funcs for enums

### DIFF
--- a/changelog/@unreleased/pr-160.v2.yml
+++ b/changelog/@unreleased/pr-160.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add IsUnknown() and Values() funcs for enums
+  links:
+  - https://github.com/palantir/conjure-go/pull/160

--- a/conjure-api/conjure/spec/enums.conjure.go
+++ b/conjure-api/conjure/spec/enums.conjure.go
@@ -33,7 +33,7 @@ func ErrorCode_Values() []ErrorCode {
 	return []ErrorCode{ErrorCodePermissionDenied, ErrorCodeInvalidArgument, ErrorCodeNotFound, ErrorCodeConflict, ErrorCodeRequestEntityTooLarge, ErrorCodeFailedPrecondition, ErrorCodeInternal, ErrorCodeTimeout, ErrorCodeCustomClient, ErrorCodeCustomServer}
 }
 
-// IsUnknown returns true for all known variants of ErrorCode and false otherwise.
+// IsUnknown returns false for all known variants of ErrorCode and true otherwise.
 func (e ErrorCode) IsUnknown() bool {
 	switch e {
 	case ErrorCodePermissionDenied, ErrorCodeInvalidArgument, ErrorCodeNotFound, ErrorCodeConflict, ErrorCodeRequestEntityTooLarge, ErrorCodeFailedPrecondition, ErrorCodeInternal, ErrorCodeTimeout, ErrorCodeCustomClient, ErrorCodeCustomServer:
@@ -87,7 +87,7 @@ func HttpMethod_Values() []HttpMethod {
 	return []HttpMethod{HttpMethodGet, HttpMethodPost, HttpMethodPut, HttpMethodDelete}
 }
 
-// IsUnknown returns true for all known variants of HttpMethod and false otherwise.
+// IsUnknown returns false for all known variants of HttpMethod and true otherwise.
 func (e HttpMethod) IsUnknown() bool {
 	switch e {
 	case HttpMethodGet, HttpMethodPost, HttpMethodPut, HttpMethodDelete:
@@ -136,7 +136,7 @@ func PrimitiveType_Values() []PrimitiveType {
 	return []PrimitiveType{PrimitiveTypeString, PrimitiveTypeDatetime, PrimitiveTypeInteger, PrimitiveTypeDouble, PrimitiveTypeSafelong, PrimitiveTypeBinary, PrimitiveTypeAny, PrimitiveTypeBoolean, PrimitiveTypeUuid, PrimitiveTypeRid, PrimitiveTypeBearertoken}
 }
 
-// IsUnknown returns true for all known variants of PrimitiveType and false otherwise.
+// IsUnknown returns false for all known variants of PrimitiveType and true otherwise.
 func (e PrimitiveType) IsUnknown() bool {
 	switch e {
 	case PrimitiveTypeString, PrimitiveTypeDatetime, PrimitiveTypeInteger, PrimitiveTypeDouble, PrimitiveTypeSafelong, PrimitiveTypeBinary, PrimitiveTypeAny, PrimitiveTypeBoolean, PrimitiveTypeUuid, PrimitiveTypeRid, PrimitiveTypeBearertoken:

--- a/conjure-api/conjure/spec/enums.conjure.go
+++ b/conjure-api/conjure/spec/enums.conjure.go
@@ -28,6 +28,20 @@ const (
 	ErrorCodeCustomServer          ErrorCode = "CUSTOM_SERVER"
 )
 
+// ErrorCode_Values returns all known variants of ErrorCode.
+func ErrorCode_Values() []ErrorCode {
+	return []ErrorCode{ErrorCodePermissionDenied, ErrorCodeInvalidArgument, ErrorCodeNotFound, ErrorCodeConflict, ErrorCodeRequestEntityTooLarge, ErrorCodeFailedPrecondition, ErrorCodeInternal, ErrorCodeTimeout, ErrorCodeCustomClient, ErrorCodeCustomServer}
+}
+
+// IsUnknown returns true for all known variants of ErrorCode and false otherwise.
+func (e ErrorCode) IsUnknown() bool {
+	switch e {
+	case ErrorCodePermissionDenied, ErrorCodeInvalidArgument, ErrorCodeNotFound, ErrorCodeConflict, ErrorCodeRequestEntityTooLarge, ErrorCodeFailedPrecondition, ErrorCodeInternal, ErrorCodeTimeout, ErrorCodeCustomClient, ErrorCodeCustomServer:
+		return false
+	}
+	return true
+}
+
 func (e *ErrorCode) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -68,6 +82,20 @@ const (
 	HttpMethodDelete HttpMethod = "DELETE"
 )
 
+// HttpMethod_Values returns all known variants of HttpMethod.
+func HttpMethod_Values() []HttpMethod {
+	return []HttpMethod{HttpMethodGet, HttpMethodPost, HttpMethodPut, HttpMethodDelete}
+}
+
+// IsUnknown returns true for all known variants of HttpMethod and false otherwise.
+func (e HttpMethod) IsUnknown() bool {
+	switch e {
+	case HttpMethodGet, HttpMethodPost, HttpMethodPut, HttpMethodDelete:
+		return false
+	}
+	return true
+}
+
 func (e *HttpMethod) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -102,6 +130,20 @@ const (
 	PrimitiveTypeRid         PrimitiveType = "RID"
 	PrimitiveTypeBearertoken PrimitiveType = "BEARERTOKEN"
 )
+
+// PrimitiveType_Values returns all known variants of PrimitiveType.
+func PrimitiveType_Values() []PrimitiveType {
+	return []PrimitiveType{PrimitiveTypeString, PrimitiveTypeDatetime, PrimitiveTypeInteger, PrimitiveTypeDouble, PrimitiveTypeSafelong, PrimitiveTypeBinary, PrimitiveTypeAny, PrimitiveTypeBoolean, PrimitiveTypeUuid, PrimitiveTypeRid, PrimitiveTypeBearertoken}
+}
+
+// IsUnknown returns true for all known variants of PrimitiveType and false otherwise.
+func (e PrimitiveType) IsUnknown() bool {
+	switch e {
+	case PrimitiveTypeString, PrimitiveTypeDatetime, PrimitiveTypeInteger, PrimitiveTypeDouble, PrimitiveTypeSafelong, PrimitiveTypeBinary, PrimitiveTypeAny, PrimitiveTypeBoolean, PrimitiveTypeUuid, PrimitiveTypeRid, PrimitiveTypeBearertoken:
+		return false
+	}
+	return true
+}
 
 func (e *PrimitiveType) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {

--- a/conjure-go-verifier/conjure/verification/types/enums.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/enums.conjure.go
@@ -20,6 +20,20 @@ const (
 	EnumTwo Enum = "TWO"
 )
 
+// Enum_Values returns all known variants of Enum.
+func Enum_Values() []Enum {
+	return []Enum{EnumOne, EnumTwo}
+}
+
+// IsUnknown returns true for all known variants of Enum and false otherwise.
+func (e Enum) IsUnknown() bool {
+	switch e {
+	case EnumOne, EnumTwo:
+		return false
+	}
+	return true
+}
+
 func (e *Enum) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -42,6 +56,20 @@ const (
 	EnumExampleTwo        EnumExample = "TWO"
 	EnumExampleOneHundred EnumExample = "ONE_HUNDRED"
 )
+
+// EnumExample_Values returns all known variants of EnumExample.
+func EnumExample_Values() []EnumExample {
+	return []EnumExample{EnumExampleOne, EnumExampleTwo, EnumExampleOneHundred}
+}
+
+// IsUnknown returns true for all known variants of EnumExample and false otherwise.
+func (e EnumExample) IsUnknown() bool {
+	switch e {
+	case EnumExampleOne, EnumExampleTwo, EnumExampleOneHundred:
+		return false
+	}
+	return true
+}
 
 func (e *EnumExample) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {

--- a/conjure-go-verifier/conjure/verification/types/enums.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/enums.conjure.go
@@ -25,7 +25,7 @@ func Enum_Values() []Enum {
 	return []Enum{EnumOne, EnumTwo}
 }
 
-// IsUnknown returns true for all known variants of Enum and false otherwise.
+// IsUnknown returns false for all known variants of Enum and true otherwise.
 func (e Enum) IsUnknown() bool {
 	switch e {
 	case EnumOne, EnumTwo:
@@ -62,7 +62,7 @@ func EnumExample_Values() []EnumExample {
 	return []EnumExample{EnumExampleOne, EnumExampleTwo, EnumExampleOneHundred}
 }
 
-// IsUnknown returns true for all known variants of EnumExample and false otherwise.
+// IsUnknown returns false for all known variants of EnumExample and true otherwise.
 func (e EnumExample) IsUnknown() bool {
 	switch e {
 	case EnumExampleOne, EnumExampleTwo, EnumExampleOneHundred:

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -346,6 +346,20 @@ const (
 	ExampleEnumerationB ExampleEnumeration = "B"
 )
 
+// ExampleEnumeration_Values returns all known variants of ExampleEnumeration.
+func ExampleEnumeration_Values() []ExampleEnumeration {
+	return []ExampleEnumeration{ExampleEnumerationA, ExampleEnumerationB}
+}
+
+// IsUnknown returns true for all known variants of ExampleEnumeration and false otherwise.
+func (e ExampleEnumeration) IsUnknown() bool {
+	switch e {
+	case ExampleEnumerationA, ExampleEnumerationB:
+		return false
+	}
+	return true
+}
+
 func (e *ExampleEnumeration) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -605,6 +619,20 @@ const (
 	MonthsMultiMonths Months = "MULTI_MONTHS"
 )
 
+// Months_Values returns all known variants of Months.
+func Months_Values() []Months {
+	return []Months{MonthsJanuary, MonthsMultiMonths}
+}
+
+// IsUnknown returns true for all known variants of Months and false otherwise.
+func (e Months) IsUnknown() bool {
+	switch e {
+	case MonthsJanuary, MonthsMultiMonths:
+		return false
+	}
+	return true
+}
+
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -626,6 +654,20 @@ const (
 	DaysFriday   Days = "FRIDAY"
 	DaysSaturday Days = "SATURDAY"
 )
+
+// Days_Values returns all known variants of Days.
+func Days_Values() []Days {
+	return []Days{DaysFriday, DaysSaturday}
+}
+
+// IsUnknown returns true for all known variants of Days and false otherwise.
+func (e Days) IsUnknown() bool {
+	switch e {
+	case DaysFriday, DaysSaturday:
+		return false
+	}
+	return true
+}
 
 func (e *Days) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -351,7 +351,7 @@ func ExampleEnumeration_Values() []ExampleEnumeration {
 	return []ExampleEnumeration{ExampleEnumerationA, ExampleEnumerationB}
 }
 
-// IsUnknown returns true for all known variants of ExampleEnumeration and false otherwise.
+// IsUnknown returns false for all known variants of ExampleEnumeration and true otherwise.
 func (e ExampleEnumeration) IsUnknown() bool {
 	switch e {
 	case ExampleEnumerationA, ExampleEnumerationB:
@@ -624,7 +624,7 @@ func Months_Values() []Months {
 	return []Months{MonthsJanuary, MonthsMultiMonths}
 }
 
-// IsUnknown returns true for all known variants of Months and false otherwise.
+// IsUnknown returns false for all known variants of Months and true otherwise.
 func (e Months) IsUnknown() bool {
 	switch e {
 	case MonthsJanuary, MonthsMultiMonths:
@@ -660,7 +660,7 @@ func Days_Values() []Days {
 	return []Days{DaysFriday, DaysSaturday}
 }
 
-// IsUnknown returns true for all known variants of Days and false otherwise.
+// IsUnknown returns false for all known variants of Days and true otherwise.
 func (e Days) IsUnknown() bool {
 	switch e {
 	case DaysFriday, DaysSaturday:

--- a/conjure/enum.go
+++ b/conjure/enum.go
@@ -15,6 +15,7 @@
 package conjure
 
 import (
+	"fmt"
 	"go/token"
 
 	"github.com/danverbraganza/varcaser/varcaser"
@@ -58,9 +59,11 @@ func astForEnum(enumDefinition spec.EnumDefinition, info types.PkgInfo) []astgen
 	}
 	valsDecl := &decl.Const{Values: vals}
 
+	valuesFuncDecl := enumValuesAST(enumDefinition)
+	isUnknownDecl := enumIsUnknownAST(enumDefinition)
 	unmarshalDecl := enumUnmarshalTextAST(enumDefinition, info)
 
-	return []astgen.ASTDecl{typeDef, valsDecl, unmarshalDecl}
+	return []astgen.ASTDecl{typeDef, valsDecl, valuesFuncDecl, isUnknownDecl, unmarshalDecl}
 }
 
 func astForEnumPattern(info types.PkgInfo) astgen.ASTDecl {
@@ -133,4 +136,56 @@ func enumUnmarshalTextAST(e spec.EnumDefinition, info types.PkgInfo) astgen.ASTD
 		))
 	}
 	return newUnmarshalTextMethod(enumReceiverName, transforms.Export(e.TypeName.Name), switchStmt, statement.NewReturn(expression.Nil))
+}
+
+func enumIsUnknownAST(e spec.EnumDefinition) astgen.ASTDecl {
+	typeName := transforms.Export(e.TypeName.Name)
+	return &decl.Method{
+		ReceiverName: enumReceiverName,
+		ReceiverType: expression.Type(transforms.Export(e.TypeName.Name)),
+		Function: decl.Function{
+			Comment: fmt.Sprintf("IsUnknown returns true for all known variants of %s and false otherwise.", typeName),
+			Name:    "IsUnknown",
+			FuncType: expression.FuncType{
+				ReturnTypes: []expression.Type{expression.BoolType},
+			},
+			Body: []astgen.ASTStmt{
+				&statement.Switch{
+					Expression: expression.VariableVal(enumReceiverName),
+					Cases: []statement.CaseClause{
+						{
+							Exprs: enumValuesToExprs(e),
+							Body:  []astgen.ASTStmt{statement.NewReturn(expression.VariableVal("false"))},
+						},
+					},
+				},
+				statement.NewReturn(expression.VariableVal("true")),
+			},
+		},
+	}
+}
+
+func enumValuesAST(e spec.EnumDefinition) astgen.ASTDecl {
+	typeName := transforms.Export(e.TypeName.Name)
+	funcName := typeName + "_Values"
+	sliceType := expression.Type("[]" + transforms.Export(e.TypeName.Name))
+	return &decl.Function{
+		Comment: fmt.Sprintf("%s returns all known variants of %s.", funcName, typeName),
+		Name:    funcName,
+		FuncType: expression.FuncType{
+			ReturnTypes: []expression.Type{sliceType},
+		},
+		Body: []astgen.ASTStmt{
+			statement.NewReturn(expression.NewCompositeLit(sliceType, enumValuesToExprs(e)...)),
+		},
+	}
+}
+
+func enumValuesToExprs(e spec.EnumDefinition) []astgen.ASTExpr {
+	toCamelCase := varcaser.Caser{From: varcaser.ScreamingSnakeCase, To: varcaser.UpperCamelCase}.String
+	values := make([]astgen.ASTExpr, 0, len(e.Values))
+	for _, currVal := range e.Values {
+		values = append(values, expression.VariableVal(e.TypeName.Name+toCamelCase(currVal.Value)))
+	}
+	return values
 }

--- a/conjure/enum.go
+++ b/conjure/enum.go
@@ -144,7 +144,7 @@ func enumIsUnknownAST(e spec.EnumDefinition) astgen.ASTDecl {
 		ReceiverName: enumReceiverName,
 		ReceiverType: expression.Type(transforms.Export(e.TypeName.Name)),
 		Function: decl.Function{
-			Comment: fmt.Sprintf("IsUnknown returns true for all known variants of %s and false otherwise.", typeName),
+			Comment: fmt.Sprintf("IsUnknown returns false for all known variants of %s and true otherwise.", typeName),
 			Name:    "IsUnknown",
 			FuncType: expression.FuncType{
 				ReturnTypes: []expression.Type{expression.BoolType},

--- a/conjure/enum_test.go
+++ b/conjure/enum_test.go
@@ -65,7 +65,7 @@ func Months_Values() []Months {
 	return []Months{MonthsJanuary, MonthsFebruary}
 }
 
-// IsUnknown returns true for all known variants of Months and false otherwise.
+// IsUnknown returns false for all known variants of Months and true otherwise.
 func (e Months) IsUnknown() bool {
 	switch e {
 	case MonthsJanuary, MonthsFebruary:
@@ -132,7 +132,7 @@ func Months_Values() []Months {
 	return []Months{MonthsJanuary, MonthsFebruary}
 }
 
-// IsUnknown returns true for all known variants of Months and false otherwise.
+// IsUnknown returns false for all known variants of Months and true otherwise.
 func (e Months) IsUnknown() bool {
 	switch e {
 	case MonthsJanuary, MonthsFebruary:
@@ -168,7 +168,7 @@ func Values_Values() []Values {
 	return []Values{ValuesNullValue, ValuesValidValue}
 }
 
-// IsUnknown returns true for all known variants of Values and false otherwise.
+// IsUnknown returns false for all known variants of Values and true otherwise.
 func (e Values) IsUnknown() bool {
 	switch e {
 	case ValuesNullValue, ValuesValidValue:
@@ -231,7 +231,7 @@ func Months_Values() []Months {
 	return []Months{MonthsJanuary, MonthsFebruary}
 }
 
-// IsUnknown returns true for all known variants of Months and false otherwise.
+// IsUnknown returns false for all known variants of Months and true otherwise.
 func (e Months) IsUnknown() bool {
 	switch e {
 	case MonthsJanuary, MonthsFebruary:

--- a/conjure/enum_test.go
+++ b/conjure/enum_test.go
@@ -60,6 +60,19 @@ const (
 	MonthsFebruary Months = "FEBRUARY"
 )
 
+// Months_Values returns all known variants of Months.
+func Months_Values() []Months {
+	return []Months{MonthsJanuary, MonthsFebruary}
+}
+
+// IsUnknown returns true for all known variants of Months and false otherwise.
+func (e Months) IsUnknown() bool {
+	switch e {
+	case MonthsJanuary, MonthsFebruary:
+		return false
+	}
+	return true
+}
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -114,6 +127,19 @@ const (
 	MonthsFebruary Months = "FEBRUARY"
 )
 
+// Months_Values returns all known variants of Months.
+func Months_Values() []Months {
+	return []Months{MonthsJanuary, MonthsFebruary}
+}
+
+// IsUnknown returns true for all known variants of Months and false otherwise.
+func (e Months) IsUnknown() bool {
+	switch e {
+	case MonthsJanuary, MonthsFebruary:
+		return false
+	}
+	return true
+}
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -137,6 +163,19 @@ const (
 	ValuesValidValue Values = "VALID_VALUE"
 )
 
+// Values_Values returns all known variants of Values.
+func Values_Values() []Values {
+	return []Values{ValuesNullValue, ValuesValidValue}
+}
+
+// IsUnknown returns true for all known variants of Values and false otherwise.
+func (e Values) IsUnknown() bool {
+	switch e {
+	case ValuesNullValue, ValuesValidValue:
+		return false
+	}
+	return true
+}
 func (e *Values) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
@@ -187,6 +226,19 @@ const (
 	MonthsFebruary Months = "FEBRUARY"
 )
 
+// Months_Values returns all known variants of Months.
+func Months_Values() []Months {
+	return []Months{MonthsJanuary, MonthsFebruary}
+}
+
+// IsUnknown returns true for all known variants of Months and false otherwise.
+func (e Months) IsUnknown() bool {
+	switch e {
+	case MonthsJanuary, MonthsFebruary:
+		return false
+	}
+	return true
+}
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -21,6 +21,20 @@ const (
 	EnumValue2 Enum = "VALUE2"
 )
 
+// Enum_Values returns all known variants of Enum.
+func Enum_Values() []Enum {
+	return []Enum{EnumValue1, EnumValue2}
+}
+
+// IsUnknown returns true for all known variants of Enum and false otherwise.
+func (e Enum) IsUnknown() bool {
+	switch e {
+	case EnumValue1, EnumValue2:
+		return false
+	}
+	return true
+}
+
 func (e *Enum) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -26,7 +26,7 @@ func Enum_Values() []Enum {
 	return []Enum{EnumValue1, EnumValue2}
 }
 
-// IsUnknown returns true for all known variants of Enum and false otherwise.
+// IsUnknown returns false for all known variants of Enum and true otherwise.
 func (e Enum) IsUnknown() bool {
 	switch e {
 	case EnumValue1, EnumValue2:

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -376,3 +376,12 @@ func TestEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestEnumIsUnknown(t *testing.T) {
+	assert.False(t, api.EnumValue1.IsUnknown())
+	assert.True(t, api.Enum("OTHER").IsUnknown())
+}
+
+func TestEnumValues(t *testing.T) {
+	assert.Equal(t, []api.Enum{api.EnumValue1, api.EnumValue2}, api.Enum_Values())
+}


### PR DESCRIPTION
## Before this PR
When we removed the `UNKOWN` variant in #139, it made it difficult for consumers to know if their value is valid or not.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add IsUnknown() and Values() funcs for enums
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/160)
<!-- Reviewable:end -->
