### PR TITLE
Fix generated code for external type with fallback

### DIFF
--- a/changelog/@unreleased/pr-165.v2.yml
+++ b/changelog/@unreleased/pr-165.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Makes it so that generated server code for external types with fallback
+    compiles.
+  links:
+  - https://github.com/palantir/conjure-go/pull/165

--- a/conjure/visitors/visit_http_param.go
+++ b/conjure/visitors/visit_http_param.go
@@ -196,7 +196,7 @@ func (v *httpParamVisitor) VisitExternal(t spec.ExternalReference) error {
 	v.result = append(v.result, fallbackVisitor.result...)
 	v.result = append(v.result, &statement.Assignment{
 		LHS: []astgen.ASTExpr{expression.VariableVal(v.argName)},
-		Tok: token.ASSIGN,
+		Tok: token.DEFINE,
 		RHS: &expression.CallExpression{
 			Function: expression.VariableVal(typer.GoType(v.info)),
 			Args:     []astgen.ASTExpr{expression.VariableVal(fallbackVisitor.argName)},

--- a/conjure/visitors/visit_http_param_test.go
+++ b/conjure/visitors/visit_http_param_test.go
@@ -541,7 +541,7 @@ if err := safejson.Unmarshal([]byte(myArgQuote), &myArg); err != nil {
 			ExpectedImports: []string{"com.example.foo.foo"},
 			//TODO(bmoylan) This output is wrong - how are external imports supposed to work?
 			ExpectedSrc: `myArgInternal := myString
-myArg = com.example.foo.foo.Foo(myArgInternal)`,
+myArg := com.example.foo.foo.Foo(myArgInternal)`,
 		},
 		{
 			Name:    "Map param",


### PR DESCRIPTION
Fixes #163

## Before this PR
Generated code for types defined as external imports but with a fallback type would not compile because we used an assignment rather than a define operator.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Makes it so that generated server code for external types with fallback compiles.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/165)
<!-- Reviewable:end -->
