### PR TITLE
Fix: Don't fail deserialization on invalid enum values

### DIFF
--- a/changelog/@unreleased/pr-169.v2.yml
+++ b/changelog/@unreleased/pr-169.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Don't fail deserialization on invalid enum values, making behavior
+    consistent with conjure-java.
+  links:
+  - https://github.com/palantir/conjure-go/pull/169

--- a/conjure-api/conjure/spec/enums.conjure.go
+++ b/conjure-api/conjure/spec/enums.conjure.go
@@ -3,15 +3,8 @@
 package spec
 
 import (
-	"regexp"
 	"strings"
-
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
-
-var enumValuePattern = regexp.MustCompile("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
 
 type ErrorCode struct {
 	val ErrorCode_Value
@@ -69,9 +62,6 @@ func (e ErrorCode) MarshalText() ([]byte, error) {
 func (e *ErrorCode) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "ErrorCode", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_ErrorCode(ErrorCode_Value(v))
 	case "PERMISSION_DENIED":
 		*e = New_ErrorCode(ErrorCode_PERMISSION_DENIED)
@@ -147,9 +137,6 @@ func (e HttpMethod) MarshalText() ([]byte, error) {
 func (e *HttpMethod) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "HttpMethod", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_HttpMethod(HttpMethod_Value(v))
 	case "GET":
 		*e = New_HttpMethod(HttpMethod_GET)
@@ -220,9 +207,6 @@ func (e PrimitiveType) MarshalText() ([]byte, error) {
 func (e *PrimitiveType) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "PrimitiveType", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_PrimitiveType(PrimitiveType_Value(v))
 	case "STRING":
 		*e = New_PrimitiveType(PrimitiveType_STRING)

--- a/conjure-go-verifier/conjure/verification/types/enums.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/enums.conjure.go
@@ -3,15 +3,8 @@
 package types
 
 import (
-	"regexp"
 	"strings"
-
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
-
-var enumValuePattern = regexp.MustCompile("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
 
 type Enum struct {
 	val Enum_Value
@@ -61,9 +54,6 @@ func (e Enum) MarshalText() ([]byte, error) {
 func (e *Enum) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Enum", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Enum(Enum_Value(v))
 	case "ONE":
 		*e = New_Enum(Enum_ONE)
@@ -122,9 +112,6 @@ func (e EnumExample) MarshalText() ([]byte, error) {
 func (e *EnumExample) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "EnumExample", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_EnumExample(EnumExample_Value(v))
 	case "ONE":
 		*e = New_EnumExample(EnumExample_ONE)

--- a/conjure-go-verifier/ignored-test-cases.yml
+++ b/conjure-go-verifier/ignored-test-cases.yml
@@ -111,6 +111,9 @@ client:
     - "null"
     receiveSetDoubleAliasExample:
     - "[100, 10.0, \"NaN\", \"Infinity\", \"-Infinity\"]"
+    receiveEnumExample:
+    - "\"!!!\""
+    - "\"one-hundred\""
   singlePathParamService:
     pathParamAliasString:
     - '""'

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -188,10 +188,6 @@ func (c *outputFileCollector) VisitAlias(aliasDefinition spec.AliasDefinition) e
 }
 
 func (c *outputFileCollector) VisitEnum(enumDefinition spec.EnumDefinition) error {
-	if len(c.enums.Decls) == 0 {
-		// if this is our first enum, add the regex pattern
-		c.enums.Decls = append(c.enums.Decls, astForEnumPattern(c.enums.Info))
-	}
 	decls := astForEnum(enumDefinition, c.enums.Info)
 	c.enums.Decls = append(c.enums.Decls, decls...)
 	return nil

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -329,15 +329,8 @@ var testCases = []struct {
 package api
 
 import (
-	"regexp"
 	"strings"
-
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
-
-var enumValuePattern = regexp.MustCompile("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
 
 type ExampleEnumeration struct {
 	val ExampleEnumeration_Value
@@ -387,9 +380,6 @@ func (e ExampleEnumeration) MarshalText() ([]byte, error) {
 func (e *ExampleEnumeration) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "ExampleEnumeration", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_ExampleEnumeration(ExampleEnumeration_Value(v))
 	case "A":
 		*e = New_ExampleEnumeration(ExampleEnumeration_A)
@@ -626,15 +616,8 @@ func (a *AliasAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
 package api
 
 import (
-	"regexp"
 	"strings"
-
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
-
-var enumValuePattern = regexp.MustCompile("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
 
 type Months struct {
 	val Months_Value
@@ -684,9 +667,6 @@ func (e Months) MarshalText() ([]byte, error) {
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Months", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Months(Months_Value(v))
 	case "JANUARY":
 		*e = New_Months(Months_JANUARY)
@@ -744,9 +724,6 @@ func (e Days) MarshalText() ([]byte, error) {
 func (e *Days) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Days", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Days(Days_Value(v))
 	case "FRIDAY":
 		*e = New_Days(Days_FRIDAY)

--- a/conjure/enum_test.go
+++ b/conjure/enum_test.go
@@ -96,9 +96,6 @@ func (e Months) MarshalText() ([]byte, error) {
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Months", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Months(Months_Value(v))
 	case "JANUARY":
 		*e = New_Months(Months_JANUARY)
@@ -184,9 +181,6 @@ func (e Months) MarshalText() ([]byte, error) {
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Months", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Months(Months_Value(v))
 	case "JANUARY":
 		*e = New_Months(Months_JANUARY)
@@ -241,9 +235,6 @@ func (e Values) MarshalText() ([]byte, error) {
 func (e *Values) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Values", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Values(Values_Value(v))
 	case "NULL_VALUE":
 		*e = New_Values(Values_NULL_VALUE)
@@ -325,9 +316,6 @@ func (e Months) MarshalText() ([]byte, error) {
 func (e *Months) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Months", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Months(Months_Value(v))
 	case "JANUARY":
 		*e = New_Months(Months_JANUARY)

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -3,15 +3,8 @@
 package api
 
 import (
-	"regexp"
 	"strings"
-
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
-
-var enumValuePattern = regexp.MustCompile("^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$")
 
 type Days struct {
 	val Days_Value
@@ -61,9 +54,6 @@ func (e Days) MarshalText() ([]byte, error) {
 func (e *Days) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Days", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Days(Days_Value(v))
 	case "FRIDAY":
 		*e = New_Days(Days_FRIDAY)
@@ -126,9 +116,6 @@ func (e Enum) MarshalText() ([]byte, error) {
 func (e *Enum) UnmarshalText(data []byte) error {
 	switch v := strings.ToUpper(string(data)); v {
 	default:
-		if !enumValuePattern.MatchString(v) {
-			return werror.Convert(errors.NewInvalidArgument(wparams.NewSafeAndUnsafeParamStorer(map[string]interface{}{"enumType": "Enum", "message": "enum value must match pattern ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}, map[string]interface{}{"enumValue": string(data)})))
-		}
 		*e = New_Enum(Enum_Value(v))
 	case "VALUE":
 		*e = New_Enum(Enum_VALUE)

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -328,10 +328,9 @@ func TestEnum(t *testing.T) {
 	})
 
 	for _, test := range []struct {
-		Name      string
-		JSON      string
-		Expected  api.Enum_Value
-		ExpectErr bool
+		Name     string
+		JSON     string
+		Expected api.Enum_Value
 	}{
 		{
 			Name:     "basic",
@@ -355,20 +354,16 @@ func TestEnum(t *testing.T) {
 			Expected: api.Enum_Value("UNKNOWN_VALUE"),
 		},
 		{
-			Name:      "invalid character",
-			JSON:      `"INVALID-VALUE"`,
-			ExpectErr: true,
+			Name:     "invalid character",
+			JSON:     `"invalid-VALUE"`,
+			Expected: "INVALID-VALUE",
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			var val api.Enum
 			err := json.Unmarshal([]byte(test.JSON), &val)
-			if test.ExpectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.EqualValues(t, test.Expected, val.String())
-			}
+			require.NoError(t, err)
+			assert.EqualValues(t, test.Expected, val.String())
 		})
 	}
 }


### PR DESCRIPTION
## Before this PR
When enum roundtripping was added, a constraint was also added to deserialization that would throw an error if a value failed to meet the constraints applied when generating conjure IR. However, this was inconsistent with [conjure-java](https://github.com/palantir/conjure-java/blob/6816a503a153840a3a9949db4087bcf2366c2045/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SimpleEnum.java#L60-L70), and was stricter than the conjure spec requires.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Don't fail deserialization on invalid enum values, making behavior consistent with conjure-java.
==COMMIT_MSG==

By removing this constraint, conjure-go's behavior matches conjure-java.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/169)
<!-- Reviewable:end -->
