### PR TITLE
Improvement: Use latest CGR wrapped error helpers

### DIFF
--- a/changelog/@unreleased/pr-170.v2.yml
+++ b/changelog/@unreleased/pr-170.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Use latest CGR wrapped error helpers, specifically the new `WrapWith*`
+    constructors for generic error types and `GetConjureError` function for retrieving
+    a nested conjure error.
+  links:
+  - https://github.com/palantir/conjure-go/pull/170

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2358,7 +2358,7 @@ func IsMyNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := werror.RootCause(err).(*MyNotFound)
+	_, ok := errors.GetConjureError(err).(*MyNotFound)
 	return ok
 }
 

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -954,7 +954,7 @@ func astErrorInitFunc(errorDefinitions []spec.ErrorDefinition, info types.PkgInf
 //	   if err == nil {
 //		   return false
 //	   }
-//	   _, ok := werror.RootCause(err).(*MyNotFound)
+//	   _, ok := errors.GetConjureError(err).(*MyNotFound)
 //	   return ok
 // }
 func astIsErrorTypeFunc(errorDefinition spec.ErrorDefinition, info types.PkgInfo) astgen.ASTDecl {
@@ -996,7 +996,7 @@ func astIsErrorTypeFunc(errorDefinition spec.ErrorDefinition, info types.PkgInfo
 				},
 				Tok: token.DEFINE,
 				RHS: &expression.TypeAssert{
-					Receiver: expression.NewCallFunction("werror", "RootCause", expression.VariableVal(errVarName)),
+					Receiver: expression.NewCallFunction("errors", "GetConjureError", expression.VariableVal(errVarName)),
 					Type:     expression.Type(fmt.Sprintf("*%s", errorDefinition.ErrorName.Name)),
 				},
 			},

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -529,8 +529,7 @@ func getBodyParamStatements(bodyParam *visitors.ArgumentDefinitionBodyParam, inf
 			Body: []astgen.ASTStmt{
 				&statement.Return{
 					Values: []astgen.ASTExpr{
-						getNewWrappedError(getNewConjureError("NewInvalidArgument", nil),
-							expression.VariableVal(errorName)),
+						getWrappedConjureError("WrapWithInvalidArgument", expression.VariableVal(errorName), nil),
 					}},
 			},
 		})
@@ -546,9 +545,12 @@ func getNewConjureError(errorType string, paramsVal astgen.ASTExpr) astgen.ASTEx
 	return expression.NewCallFunction(errorsImportPackage, errorType, paramsVal)
 }
 
-// errors.NewWrappedError(err, conjureErr)
-func getNewWrappedError(conjureErr, err astgen.ASTExpr) astgen.ASTExpr {
-	return expression.NewCallFunction(errorsImportPackage, "NewWrappedError", conjureErr, err)
+// errors.NewInvalidArgument(params)
+func getWrappedConjureError(errorType string, wrappedErr astgen.ASTExpr, paramsVal astgen.ASTExpr) astgen.ASTExpr {
+	if paramsVal == nil {
+		return expression.NewCallFunction(errorsImportPackage, errorType, wrappedErr)
+	}
+	return expression.NewCallFunction(errorsImportPackage, errorType, wrappedErr, paramsVal)
 }
 
 func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStmt, error) {
@@ -578,8 +580,7 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 				Body: []astgen.ASTStmt{
 					&statement.Return{
 						Values: []astgen.ASTExpr{
-							getNewWrappedError(getNewConjureError("NewPermissionDenied", nil),
-								expression.VariableVal(errorName)),
+							getWrappedConjureError("WrapWithPermissionDenied", expression.VariableVal(errorName), nil),
 						}},
 				},
 			},
@@ -609,8 +610,7 @@ func getAuthStatements(auth *spec.AuthType, info types.PkgInfo) ([]astgen.ASTStm
 				Body: []astgen.ASTStmt{
 					&statement.Return{
 						Values: []astgen.ASTExpr{
-							getNewWrappedError(getNewConjureError("NewPermissionDenied", nil),
-								expression.VariableVal(errorName)),
+							getWrappedConjureError("WrapWithPermissionDenied", expression.VariableVal(errorName), nil),
 						}},
 				},
 			},

--- a/integration_test/testgenerated/auth/api/servers.conjure.go
+++ b/integration_test/testgenerated/auth/api/servers.conjure.go
@@ -51,7 +51,7 @@ type bothAuthServiceHandler struct {
 func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	respArg, err := b.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -64,7 +64,7 @@ func (b *bothAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http
 func (b *bothAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return b.impl.Cookie(req.Context(), cookieToken)
@@ -77,11 +77,11 @@ func (b *bothAuthServiceHandler) HandleNone(rw http.ResponseWriter, req *http.Re
 func (b *bothAuthServiceHandler) HandleWithArg(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var arg string
 	if err := codecs.JSON.Decode(req.Body, &arg); err != nil {
-		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+		return errors.WrapWithInvalidArgument(err)
 	}
 	return b.impl.WithArg(req.Context(), bearertoken.Token(authHeader), arg)
 }
@@ -110,7 +110,7 @@ type cookieAuthServiceHandler struct {
 func (c *cookieAuthServiceHandler) HandleCookie(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("P_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return c.impl.Cookie(req.Context(), cookieToken)
@@ -140,7 +140,7 @@ type headerAuthServiceHandler struct {
 func (h *headerAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	respArg, err := h.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {
@@ -178,7 +178,7 @@ type someHeaderAuthServiceHandler struct {
 func (s *someHeaderAuthServiceHandler) HandleDefault(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	respArg, err := s.impl.Default(req.Context(), bearertoken.Token(authHeader))
 	if err != nil {

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -88,7 +88,7 @@ func IsMyInternal(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := werror.RootCause(err).(*MyInternal)
+	_, ok := errors.GetConjureError(err).(*MyInternal)
 	return ok
 }
 
@@ -267,7 +267,7 @@ func IsMyNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := werror.RootCause(err).(*MyNotFound)
+	_, ok := errors.GetConjureError(err).(*MyNotFound)
 	return ok
 }
 

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -38,7 +38,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	var input string
 	if err := codecs.JSON.Decode(req.Body, &input); err != nil {
-		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+		return errors.WrapWithInvalidArgument(err)
 	}
 	respArg, err := t.impl.Echo(req.Context(), input)
 	if err != nil {

--- a/integration_test/testgenerated/queryparam/queryparam_test.go
+++ b/integration_test/testgenerated/queryparam/queryparam_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	werror "github.com/palantir/witchcraft-go-error"
 	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/palantir/witchcraft-go-server/v2/wrouter"
 	"github.com/palantir/witchcraft-go-server/v2/wrouter/whttprouter"
@@ -46,7 +45,7 @@ func TestQueryParamClient(t *testing.T) {
 
 	_, err = client.Echo(context.Background(), "hello", -3, &optionalStr, listArg, nil)
 	if assert.Error(t, err) {
-		cerr := werror.RootCause(err).(errors.Error)
+		cerr := errors.GetConjureError(err)
 		assert.Equal(t, "reps must be non-negative, was -3", cerr.UnsafeParams()["message"])
 		assert.Equal(t, errors.InvalidArgument, cerr.Code())
 	}

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -119,7 +119,7 @@ type testServiceHandler struct {
 func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Request) error {
 	authCookie, err := req.Cookie("PALANTIR_TOKEN")
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
 	return t.impl.Echo(req.Context(), cookieToken)
@@ -128,7 +128,7 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -144,7 +144,7 @@ func (t *testServiceHandler) HandleGetPathParam(rw http.ResponseWriter, req *htt
 func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -165,7 +165,7 @@ func (t *testServiceHandler) HandleGetPathParamAlias(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamList(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -174,7 +174,7 @@ func (t *testServiceHandler) HandleQueryParamList(rw http.ResponseWriter, req *h
 func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []bool
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -190,7 +190,7 @@ func (t *testServiceHandler) HandleQueryParamListBoolean(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []datetime.DateTime
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -206,7 +206,7 @@ func (t *testServiceHandler) HandleQueryParamListDateTime(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []float64
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -222,7 +222,7 @@ func (t *testServiceHandler) HandleQueryParamListDouble(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []int
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -238,7 +238,7 @@ func (t *testServiceHandler) HandleQueryParamListInteger(rw http.ResponseWriter,
 func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []rid.ResourceIdentifier
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -254,7 +254,7 @@ func (t *testServiceHandler) HandleQueryParamListRid(rw http.ResponseWriter, req
 func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []safelong.SafeLong
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -270,7 +270,7 @@ func (t *testServiceHandler) HandleQueryParamListSafeLong(rw http.ResponseWriter
 func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	myQueryParam1 := req.URL.Query()["myQueryParam1"]
 	return t.impl.QueryParamListString(req.Context(), bearertoken.Token(authHeader), myQueryParam1)
@@ -279,7 +279,7 @@ func (t *testServiceHandler) HandleQueryParamListString(rw http.ResponseWriter, 
 func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	var myQueryParam1 []uuid.UUID
 	for _, v := range req.URL.Query()["myQueryParam1"] {
@@ -295,7 +295,7 @@ func (t *testServiceHandler) HandleQueryParamListUuid(rw http.ResponseWriter, re
 func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -346,7 +346,7 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 	}
 	var myBodyParam CustomObject
 	if err := codecs.JSON.Decode(req.Body, &myBodyParam); err != nil {
-		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+		return errors.WrapWithInvalidArgument(err)
 	}
 	respArg, err := t.impl.PostPathParam(req.Context(), bearertoken.Token(authHeader), myPathParam1, myPathParam2, myBodyParam, myQueryParam1, myQueryParam2, myQueryParam3, myQueryParam4, myQueryParam5, myHeaderParam1, myHeaderParam2)
 	if err != nil {
@@ -359,7 +359,7 @@ func (t *testServiceHandler) HandlePostPathParam(rw http.ResponseWriter, req *ht
 func (t *testServiceHandler) HandlePostSafeParams(rw http.ResponseWriter, req *http.Request) error {
 	authHeader, err := httpserver.ParseBearerTokenHeader(req)
 	if err != nil {
-		return errors.NewWrappedError(errors.NewPermissionDenied(), err)
+		return errors.WrapWithPermissionDenied(err)
 	}
 	pathParams := wrouter.PathParams(req)
 	if pathParams == nil {
@@ -410,7 +410,7 @@ func (t *testServiceHandler) HandlePostSafeParams(rw http.ResponseWriter, req *h
 	}
 	var myBodyParam CustomObject
 	if err := codecs.JSON.Decode(req.Body, &myBodyParam); err != nil {
-		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+		return errors.WrapWithInvalidArgument(err)
 	}
 	return t.impl.PostSafeParams(req.Context(), bearertoken.Token(authHeader), myPathParam1, myPathParam2, myBodyParam, myQueryParam1, myQueryParam2, myQueryParam3, myQueryParam4, myQueryParam5, myHeaderParam1, myHeaderParam2)
 }
@@ -464,7 +464,7 @@ func (t *testServiceHandler) HandleChan(rw http.ResponseWriter, req *http.Reques
 	}
 	var import_ map[string]string
 	if err := codecs.JSON.Decode(req.Body, &import_); err != nil {
-		return errors.NewWrappedError(errors.NewInvalidArgument(), err)
+		return errors.WrapWithInvalidArgument(err)
 	}
 	return t.impl.Chan(req.Context(), var_, import_, type_, return_)
 }


### PR DESCRIPTION
## Before this PR
Prior to this PR, generated conjure continued to use deprecated `NewWrappedError` function from CGR. We also used the no longer sufficient `werror.RootCause()` to retrieve nested conjure errors in the `IsMyError()` generated functions.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use latest CGR wrapped error helpers, specifically the new `WrapWith*` constructors for generic error types and `GetConjureError` function for retrieving a nested conjure error.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/170)
<!-- Reviewable:end -->
