### PR TITLE
Improvement: Add errorName as safe param to generated errors

### DIFF
--- a/changelog/@unreleased/pr-211.v2.yml
+++ b/changelog/@unreleased/pr-211.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+fix:
+  description: |
+    Add errorName as safe param to generated errors, bringing conjure-go
+    to parity with conjure-java.
+  links:
+  - https://github.com/palantir/conjure-go/pull/211

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -2504,7 +2504,7 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 
 // safeParams returns a set of named safe parameters detailing this particular error instance.
 func (e *MyNotFound) safeParams() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "errorInstanceId": e.errorInstanceID}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "errorInstanceId": e.errorInstanceID, "errorName": e.Name()}
 }
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance and

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -35,6 +35,7 @@ const (
 	causeField           = "cause"
 	stackField           = "stack"
 	errorInstanceIDParam = "errorInstanceId"
+	errorNameParam       = "errorName"
 	errVarName           = "err"
 )
 
@@ -620,13 +621,20 @@ func astErrorHelperSafeParamsMethod(errorDefinition spec.ErrorDefinition, info t
 			),
 		))
 	}
-	keyValues = append(keyValues, expression.NewKeyValue(
-		fmt.Sprintf("%q", errorInstanceIDParam),
-		expression.NewSelector(
-			expression.VariableVal(errorReceiverName),
-			errorInstanceIDField,
+	keyValues = append(keyValues,
+		expression.NewKeyValue(
+			fmt.Sprintf("%q", errorInstanceIDParam),
+			expression.NewSelector(
+				expression.VariableVal(errorReceiverName),
+				errorInstanceIDField),
 		),
-	))
+		expression.NewKeyValue(
+			fmt.Sprintf("%q", errorNameParam),
+			expression.NewCallFunction(
+				errorReceiverName,
+				"Name"),
+		),
+	)
 	return &decl.Method{
 		Function: decl.Function{
 			Name: "safeParams",

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -140,7 +140,7 @@ func (e *MyInternal) Parameters() map[string]interface{} {
 
 // safeParams returns a set of named safe parameters detailing this particular error instance.
 func (e *MyInternal) safeParams() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceId": e.errorInstanceID}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceId": e.errorInstanceID, "errorName": e.Name()}
 }
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance and
@@ -319,7 +319,7 @@ func (e *MyNotFound) Parameters() map[string]interface{} {
 
 // safeParams returns a set of named safe parameters detailing this particular error instance.
 func (e *MyNotFound) safeParams() map[string]interface{} {
-	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceId": e.errorInstanceID}
+	return map[string]interface{}{"safeArgA": e.SafeArgA, "safeArgB": e.SafeArgB, "type": e.Type, "errorInstanceId": e.errorInstanceID, "errorName": e.Name()}
 }
 
 // SafeParams returns a set of named safe parameters detailing this particular error instance and


### PR DESCRIPTION

==COMMIT_MSG==
Add errorName as safe param to generated errors, bringing conjure-go to parity with conjure-java.
==COMMIT_MSG==

In witchcraft-java, the server error handler logs "Error handling request" as the message, with `errorName` as one of the safe params. In conjure-go-server, the server error handler logs "Error handling request: %s", interpolating `err.Error()` into the message. This prevents a consistent error message. After this change to make `errorName` a safe param, it will be possible to make conjure-go-server's error logger consistent with the java one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/211)
<!-- Reviewable:end -->
