### PR TITLE
Set test parallelism to 1 to address flake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - *godel-cache-save
       - *define-tests-dir
       - *mkdir-tests-dir
-      - run: ./godelw test --tags=none --junit-output="$TESTS_DIR/$CIRCLE_PROJECT_REPONAME-tests.xml"
+      - run: ./godelw test --tags=none --junit-output="$TESTS_DIR/$CIRCLE_PROJECT_REPONAME-tests.xml" -- -p=1
       - *store-test-results
       - *store-artifacts
   conjure-verifier:

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -377,7 +377,7 @@ func outputPackageBasePath(outputDirAbsPath string) (string, error) {
 // provided directory is not within a module. Returns an error if any errors are encountered in making this
 // determination.
 func goModulePath(dir string) (modName string, modBaseDir string, rErr error) {
-	cmd := exec.Command("go", "list", "-m", "-json")
+	cmd := exec.Command("go", "list", "-m", "-mod=readonly", "-json")
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -377,7 +377,7 @@ func outputPackageBasePath(outputDirAbsPath string) (string, error) {
 // provided directory is not within a module. Returns an error if any errors are encountered in making this
 // determination.
 func goModulePath(dir string) (modName string, modBaseDir string, rErr error) {
-	cmd := exec.Command("go", "list", "-m", "-mod=readonly", "-json")
+	cmd := exec.Command("go", "list", "-m", "-json")
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Before this PR
After https://github.com/palantir/conjure-go/pull/200, we've seen a ton of builds flake on the `test` step, specifically on integration_test.go. We haven't figured out why this happens, but it may be a side effect to running go list with that flag in parallel with running that test.

## After this PR
Parallelism is reduced to 1 for the test, which means calls to `go list` no longer overlap with running the integration tests, preventing flakes. 

## Possible downsides?
This roughly doubles the time for this task, but the overall build time should remain the same as it is still dominated by the conjure-verifier task. If this becomes a concern, another option would be to break the integration tests out into their own build task in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/213)
<!-- Reviewable:end -->
