### PR TITLE
Improvement: Generate default functions for use with AcceptFuncs union visitor method

### DIFF
--- a/changelog/@unreleased/pr-215.v2.yml
+++ b/changelog/@unreleased/pr-215.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Generate default functions for use with AcceptFuncs union visitor method
+
+    [FieldName]NoopSuccess and ErrorOnUnknown functions are generated for each union type to reduce
+    boilerplate for default cases.
+  links:
+  - https://github.com/palantir/conjure-go/pull/215

--- a/conjure/conjure_test.go
+++ b/conjure/conjure_test.go
@@ -852,6 +852,30 @@ func (u *ExampleUnion) AcceptFuncs(strFunc func(string) error, otherFunc func(st
 	}
 }
 
+func (u *ExampleUnion) StrNoopSuccess(string) error {
+	return nil
+}
+
+func (u *ExampleUnion) OtherNoopSuccess(string) error {
+	return nil
+}
+
+func (u *ExampleUnion) MyMapNoopSuccess(map[string][]int) error {
+	return nil
+}
+
+func (u *ExampleUnion) TesterNoopSuccess(datasets.TestType) error {
+	return nil
+}
+
+func (u *ExampleUnion) RecursiveNoopSuccess(ExampleUnion) error {
+	return nil
+}
+
+func (u *ExampleUnion) ErrorOnUnknown(typeName string) error {
+	return fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 func (u *ExampleUnion) Accept(v ExampleUnionVisitor) error {
 	switch u.typ {
 	default:
@@ -2065,6 +2089,26 @@ func (u *ExampleUnion) AcceptFuncs(strFunc func(string) error, otherFunc func(st
 	}
 }
 
+func (u *ExampleUnion) StrNoopSuccess(string) error {
+	return nil
+}
+
+func (u *ExampleUnion) OtherNoopSuccess(string) error {
+	return nil
+}
+
+func (u *ExampleUnion) MyMapNoopSuccess(map[string][]int) error {
+	return nil
+}
+
+func (u *ExampleUnion) RecursiveNoopSuccess(ExampleUnion) error {
+	return nil
+}
+
+func (u *ExampleUnion) ErrorOnUnknown(typeName string) error {
+	return fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 func (u *ExampleUnion) Accept(v ExampleUnionVisitor) error {
 	switch u.typ {
 	default:
@@ -2211,6 +2255,18 @@ func (u *OtherUnion) AcceptFuncs(strFunc func(string) error, myMapFunc func(map[
 	case "myMap":
 		return myMapFunc(*u.myMap)
 	}
+}
+
+func (u *OtherUnion) StrNoopSuccess(string) error {
+	return nil
+}
+
+func (u *OtherUnion) MyMapNoopSuccess(map[string]int) error {
+	return nil
+}
+
+func (u *OtherUnion) ErrorOnUnknown(typeName string) error {
+	return fmt.Errorf("invalid value in union type. Type name: %s", typeName)
 }
 
 func (u *OtherUnion) Accept(v OtherUnionVisitor) error {

--- a/integration_test/testgenerated/objects/api/unions.conjure.go
+++ b/integration_test/testgenerated/objects/api/unions.conjure.go
@@ -107,6 +107,22 @@ func (u *ExampleUnion) AcceptFuncs(strFunc func(string) error, strOptionalFunc f
 	}
 }
 
+func (u *ExampleUnion) StrNoopSuccess(string) error {
+	return nil
+}
+
+func (u *ExampleUnion) StrOptionalNoopSuccess(*string) error {
+	return nil
+}
+
+func (u *ExampleUnion) OtherNoopSuccess(int) error {
+	return nil
+}
+
+func (u *ExampleUnion) ErrorOnUnknown(typeName string) error {
+	return fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 func (u *ExampleUnion) Accept(v ExampleUnionVisitor) error {
 	switch u.typ {
 	default:


### PR DESCRIPTION
[FieldName]NoopSuccess and ErrorOnUnknown functions are generated for each union type to reduce
boilerplate for default cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/215)
<!-- Reviewable:end -->
