### PR TITLE
fix: Avoid infinite recursion when resolving self-referencing types

### DIFF
--- a/changelog/@unreleased/pr-240.v2.yml
+++ b/changelog/@unreleased/pr-240.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Avoid infinite recursion when resolving self-referencing types.
+  links:
+  - https://github.com/palantir/conjure-go/pull/240

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -273,10 +273,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 			} else {
 				return errors.Errorf("Unresolved optional type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 			}
-		} else {
-			if err := t.resolveType(v.Item); err != nil {
-				return err
-			}
+		} else if err := t.resolveType(v.Item); err != nil {
+			return err
 		}
 	case *List:
 		if unresolved, ok := v.Item.(unresolvedReferencePlaceholder); ok {
@@ -285,10 +283,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 			} else {
 				return errors.Errorf("Unresolved list item type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 			}
-		} else {
-			if err := t.resolveType(v.Item); err != nil {
-				return err
-			}
+		} else if err := t.resolveType(v.Item); err != nil {
+			return err
 		}
 	case *Map:
 		if unresolved, ok := v.Key.(unresolvedReferencePlaceholder); ok {
@@ -308,10 +304,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 			} else {
 				return errors.Errorf("Unresolved map value type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 			}
-		} else {
-			if err := t.resolveType(v.Val); err != nil {
-				return err
-			}
+		} else if err := t.resolveType(v.Val); err != nil {
+			return err
 		}
 	case *AliasType:
 		if !t.isComplete(v.conjurePkg, v.Name) {
@@ -321,10 +315,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 				} else {
 					return errors.Errorf("Unresolved alias type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 				}
-			} else {
-				if err := t.resolveType(v.Item); err != nil {
-					return err
-				}
+			} else if err := t.resolveType(v.Item); err != nil {
+				return err
 			}
 			t.markComplete(v.conjurePkg, v.Name)
 		}
@@ -338,10 +330,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 					} else {
 						return errors.Errorf("Unresolved object field type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 					}
-				} else {
-					if err := t.resolveType(field.Type); err != nil {
-						return err
-					}
+				} else if err := t.resolveType(field.Type); err != nil {
+					return err
 				}
 			}
 			t.markComplete(v.conjurePkg, v.Name)
@@ -356,10 +346,8 @@ func (t *namedTypes) resolveType(typeI Type) error {
 					} else {
 						return errors.Errorf("Unresolved union field type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 					}
-				} else {
-					if err := t.resolveType(field.Type); err != nil {
-						return err
-					}
+				} else if err := t.resolveType(field.Type); err != nil {
+					return err
 				}
 			}
 			t.markComplete(v.conjurePkg, v.Name)

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -273,8 +273,11 @@ func (t *namedTypes) resolveType(typeI Type) error {
 			} else {
 				return errors.Errorf("Unresolved optional type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 			}
+		} else {
+			if err := t.resolveType(v.Item); err != nil {
+				return err
+			}
 		}
-		return t.resolveType(v.Item)
 	case *List:
 		if unresolved, ok := v.Item.(unresolvedReferencePlaceholder); ok {
 			if resolved := t.GetByName(unresolved.Ref); resolved != nil {
@@ -282,8 +285,11 @@ func (t *namedTypes) resolveType(typeI Type) error {
 			} else {
 				return errors.Errorf("Unresolved list item type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 			}
+		} else {
+			if err := t.resolveType(v.Item); err != nil {
+				return err
+			}
 		}
-		return t.resolveType(v.Item)
 	case *Map:
 		if unresolved, ok := v.Key.(unresolvedReferencePlaceholder); ok {
 			if resolved := t.GetByName(unresolved.Ref); resolved != nil {
@@ -315,9 +321,10 @@ func (t *namedTypes) resolveType(typeI Type) error {
 				} else {
 					return errors.Errorf("Unresolved alias type reference %s %s", unresolved.Ref.Package, unresolved.Ref.Name)
 				}
-			}
-			if err := t.resolveType(v.Item); err != nil {
-				return err
+			} else {
+				if err := t.resolveType(v.Item); err != nil {
+					return err
+				}
 			}
 			t.markComplete(v.conjurePkg, v.Name)
 		}
@@ -491,9 +498,5 @@ func (unresolvedReferencePlaceholder) Code() *jen.Statement {
 }
 
 func (unresolvedReferencePlaceholder) String() string {
-	panic("unresolvedReferencePlaceholder does not implement methods")
-}
-
-func (unresolvedReferencePlaceholder) Equals(t Type) bool {
 	panic("unresolvedReferencePlaceholder does not implement methods")
 }


### PR DESCRIPTION
## Before this PR

Defining a type which references itself would cause `resolveType` to panic with stack overflow because it was calling `resolveType` even when it just set the field to the resolved value. This was a noop in all cases except when it caused stack overflow.

## After this PR

Only call `resolveType` if the field is not `unresolvedReferencePlaceholder`

==COMMIT_MSG==
Avoid infinite recursion when resolving self-referencing types.
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/240)
<!-- Reviewable:end -->
