### PR TITLE
Fix: fix IsUnknown for enums with no declared values

### DIFF
--- a/changelog/@unreleased/pr-243.v2.yml
+++ b/changelog/@unreleased/pr-243.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix the IsUnknown method for enums with no declared values
+  links:
+  - https://github.com/palantir/conjure-go/pull/243

--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -92,8 +92,9 @@ func astForEnumIsUnknown(typeName string, values []*types.Field) *jen.Statement 
 					}
 				}).Block(jen.Return(jen.False()))
 			}
-		methodBody.Return(jen.True())
-		})})
+			methodBody.Return(jen.True())
+		})
+	})
 }
 
 func astForEnumValueMethod(typeName string) *jen.Statement {

--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -81,17 +81,17 @@ func astForEnumIsUnknown(typeName string, values []*types.Field) *jen.Statement 
 	return jen.Commentf("IsUnknown returns false for all known variants of %s and true otherwise.", typeName).
 		Line().
 		Func().
-		Params(jen.Id(enumReceiverName).Id(typeName)).Id("IsUnknown").Params().Params(jen.Bool()).Block(
-		jen.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).Block(
-			jen.CaseFunc(func(conds *jen.Group) {
-				for _, valDef := range values {
-					conds.Id(typeName + "_" + valDef.Name)
-				}
-			}).
-				Block(jen.Return(jen.False())),
-		),
-		jen.Return(jen.True()),
-	)
+		Params(jen.Id(enumReceiverName).Id(typeName)).Id("IsUnknown").Params().Params(jen.Bool()).BlockFunc(func(methodBody *jen.Group) {
+		if len(values) > 0 {
+			methodBody.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).Block(
+				jen.CaseFunc(func(conds *jen.Group) {
+					for _, valDef := range values {
+						conds.Id(typeName + "_" + valDef.Name)
+					}
+				}).Block(jen.Return(jen.False())))
+		}
+		methodBody.Return(jen.True())
+	})
 }
 
 func astForEnumValueMethod(typeName string) *jen.Statement {

--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -82,16 +82,18 @@ func astForEnumIsUnknown(typeName string, values []*types.Field) *jen.Statement 
 		Line().
 		Func().
 		Params(jen.Id(enumReceiverName).Id(typeName)).Id("IsUnknown").Params().Params(jen.Bool()).BlockFunc(func(methodBody *jen.Group) {
-		if len(values) > 0 {
-			methodBody.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).Block(
-				jen.CaseFunc(func(conds *jen.Group) {
+		methodBody.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).BlockFunc(func(switchBlock *jen.Group) {
+			if len(values) == 0 {
+				switchBlock.Default().Return(jen.False())
+			} else {
+				switchBlock.CaseFunc(func(conds *jen.Group) {
 					for _, valDef := range values {
 						conds.Id(typeName + "_" + valDef.Name)
 					}
-				}).Block(jen.Return(jen.False())))
-		}
+				}).Block(jen.Return(jen.False()))
+			}
 		methodBody.Return(jen.True())
-	})
+		})})
 }
 
 func astForEnumValueMethod(typeName string) *jen.Statement {

--- a/conjure/enumwriter_test.go
+++ b/conjure/enumwriter_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conjure
+
+import (
+	"testing"
+
+	"github.com/palantir/conjure-go/v6/conjure/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_EmptyEnum(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		typeName string
+		values   []*types.Field
+		expected string
+	}{
+		{
+			name:     "Empty list",
+			typeName: "EmptyValuesEnum",
+			values:   nil,
+			expected: `// IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
+func (e EmptyValuesEnum) IsUnknown() bool {
+	return true
+}`,
+		},
+		{
+			name:     "String values",
+			typeName: "Enum",
+			values: []*types.Field{
+				{
+					Name: "SATURDAY",
+					Type: types.String{},
+				},
+				{
+					Name: "SUNDAY",
+					Type: types.String{},
+				},
+			},
+			expected: `// IsUnknown returns false for all known variants of Enum and true otherwise.
+func (e Enum) IsUnknown() bool {
+	switch e.val {
+	case Enum_SATURDAY, Enum_SUNDAY:
+		return false
+	}
+	return true
+}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := astForEnumIsUnknown(tc.typeName, tc.values)
+			assert.Equal(t, tc.expected, stmt.GoString())
+		})
+	}
+
+}

--- a/conjure/enumwriter_test.go
+++ b/conjure/enumwriter_test.go
@@ -34,6 +34,10 @@ func Test_EmptyEnum(t *testing.T) {
 			values:   nil,
 			expected: `// IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
 func (e EmptyValuesEnum) IsUnknown() bool {
+	switch e.val {
+	default:
+		return false
+	}
 	return true
 }`,
 		},

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -84,6 +84,10 @@ func New_EmptyValuesEnum(value EmptyValuesEnum_Value) EmptyValuesEnum {
 
 // IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
 func (e EmptyValuesEnum) IsUnknown() bool {
+	switch e.val {
+	default:
+		return false
+	}
 	return true
 }
 

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -63,6 +63,53 @@ func (e *Days) UnmarshalText(data []byte) error {
 	return nil
 }
 
+type EmptyValuesEnum struct {
+	val EmptyValuesEnum_Value
+}
+
+type EmptyValuesEnum_Value string
+
+const (
+	EmptyValuesEnum_UNKNOWN EmptyValuesEnum_Value = "UNKNOWN"
+)
+
+// EmptyValuesEnum_Values returns all known variants of EmptyValuesEnum.
+func EmptyValuesEnum_Values() []EmptyValuesEnum_Value {
+	return []EmptyValuesEnum_Value{}
+}
+
+func New_EmptyValuesEnum(value EmptyValuesEnum_Value) EmptyValuesEnum {
+	return EmptyValuesEnum{val: value}
+}
+
+// IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
+func (e EmptyValuesEnum) IsUnknown() bool {
+	return true
+}
+
+func (e EmptyValuesEnum) Value() EmptyValuesEnum_Value {
+	if e.IsUnknown() {
+		return EmptyValuesEnum_UNKNOWN
+	}
+	return e.val
+}
+
+func (e EmptyValuesEnum) String() string {
+	return string(e.val)
+}
+
+func (e EmptyValuesEnum) MarshalText() ([]byte, error) {
+	return []byte(e.val), nil
+}
+
+func (e *EmptyValuesEnum) UnmarshalText(data []byte) error {
+	switch v := strings.ToUpper(string(data)); v {
+	default:
+		*e = New_EmptyValuesEnum(EmptyValuesEnum_Value(v))
+	}
+	return nil
+}
+
 type Enum struct {
 	val Enum_Value
 }

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -58,6 +58,8 @@ types:
           - VALUE1
           - value: VALUE2
             docs: Docs for an enum value
+      EmptyValuesEnum:
+        values: []
       Days:
         values:
           - FRIDAY

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -411,7 +411,7 @@ func TestEnumValues(t *testing.T) {
 }
 
 func TestEmptyValuesEnumIsAlwaysUnknown(t *testing.T) {
-	assert.True(t, api.New_EmptyValuesEnum("test-value").IsUnknown())
-	assert.True(t, api.New_EmptyValuesEnum(api.EmptyValuesEnum_UNKNOWN).IsUnknown())
-
+	assert.False(t, api.New_EmptyValuesEnum("test-value").IsUnknown())
+	// TODO(tabboud): Explicit unknown values should always return true
+	assert.False(t, api.New_EmptyValuesEnum(api.EmptyValuesEnum_UNKNOWN).IsUnknown())
 }

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -409,3 +409,9 @@ func TestEnumUnknownValue(t *testing.T) {
 func TestEnumValues(t *testing.T) {
 	assert.Equal(t, []api.Enum_Value{api.Enum_VALUE, api.Enum_VALUES, api.Enum_VALUES_1, api.Enum_VALUES_1_1, api.Enum_VALUE1, api.Enum_VALUE2}, api.Enum_Values())
 }
+
+func TestEmptyValuesEnumIsAlwaysUnknown(t *testing.T) {
+	assert.True(t, api.New_EmptyValuesEnum("test-value").IsUnknown())
+	assert.True(t, api.New_EmptyValuesEnum(api.EmptyValuesEnum_UNKNOWN).IsUnknown())
+
+}


### PR DESCRIPTION
## Before this PR 
Enums with an empty list of values produced non-compiling code as seen below.
```go
// IsUnknown returns false for all known variants of EmptySliceDeclFix and true otherwise.
func (e EmptySliceDeclFix) IsUnknown() bool {
	switch e.val {
	case :
		return false
	}
	return true
}
```

Prior to the migrating to Jennifer the code was as follows:
```go
// IsUnknown returns false for all known variants of EmptySliceDeclFix and true otherwise.
func (e EmptySliceDeclFix) IsUnknown() bool {
	switch e.val {
	default:
		return false
	}
	return true
}
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the IsUnknown method for enums with no declared values
==COMMIT_MSG==

**UPDATE** 

This change now just fixes the compile breaks and retains the previous behavior

---

~~This fixes the code gen, but also changes the behavior slightly to what I would consider _more correct_. As seen above, the previously generated code would always return `false` for the `IsUnknown` method. However, given that there are no known values for this enum, it seems more correct to always return `true` given there are no known variants that are allowed.~~


## Possible downsides?
- ~~Behavior change for the `IsUnknown` function which may be dependent upon by consumers.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/243)
<!-- Reviewable:end -->
