### PR TITLE
Fix: fix IsUnknown behavior to only return false for known variants

### DIFF
--- a/changelog/@unreleased/pr-245.v2.yml
+++ b/changelog/@unreleased/pr-245.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix the IsUnknown generated code behavior to only return false for
+    known variants
+  links:
+  - https://github.com/palantir/conjure-go/pull/245

--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -82,18 +82,15 @@ func astForEnumIsUnknown(typeName string, values []*types.Field) *jen.Statement 
 		Line().
 		Func().
 		Params(jen.Id(enumReceiverName).Id(typeName)).Id("IsUnknown").Params().Params(jen.Bool()).BlockFunc(func(methodBody *jen.Group) {
-		methodBody.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).BlockFunc(func(switchBlock *jen.Group) {
-			if len(values) == 0 {
-				switchBlock.Default().Return(jen.False())
-			} else {
-				switchBlock.CaseFunc(func(conds *jen.Group) {
+		if len(values) > 0 {
+			methodBody.Switch(jen.Id(enumReceiverName).Dot(enumStructFieldName)).Block(
+				jen.CaseFunc(func(conds *jen.Group) {
 					for _, valDef := range values {
 						conds.Id(typeName + "_" + valDef.Name)
 					}
-				}).Block(jen.Return(jen.False()))
-			}
-			methodBody.Return(jen.True())
-		})
+				}).Block(jen.Return(jen.False())))
+		}
+		methodBody.Return(jen.True())
 	})
 }
 

--- a/conjure/enumwriter_test.go
+++ b/conjure/enumwriter_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_EmptyEnum(t *testing.T) {
+func Test_EnumIsUnknown(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		typeName string
@@ -34,10 +34,6 @@ func Test_EmptyEnum(t *testing.T) {
 			values:   nil,
 			expected: `// IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
 func (e EmptyValuesEnum) IsUnknown() bool {
-	switch e.val {
-	default:
-		return false
-	}
 	return true
 }`,
 		},

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -84,10 +84,6 @@ func New_EmptyValuesEnum(value EmptyValuesEnum_Value) EmptyValuesEnum {
 
 // IsUnknown returns false for all known variants of EmptyValuesEnum and true otherwise.
 func (e EmptyValuesEnum) IsUnknown() bool {
-	switch e.val {
-	default:
-		return false
-	}
 	return true
 }
 

--- a/integration_test/testgenerated/objects/objects_test.go
+++ b/integration_test/testgenerated/objects/objects_test.go
@@ -411,7 +411,6 @@ func TestEnumValues(t *testing.T) {
 }
 
 func TestEmptyValuesEnumIsAlwaysUnknown(t *testing.T) {
-	assert.False(t, api.New_EmptyValuesEnum("test-value").IsUnknown())
-	// TODO(tabboud): Explicit unknown values should always return true
-	assert.False(t, api.New_EmptyValuesEnum(api.EmptyValuesEnum_UNKNOWN).IsUnknown())
+	assert.True(t, api.New_EmptyValuesEnum("test-value").IsUnknown())
+	assert.True(t, api.New_EmptyValuesEnum(api.EmptyValuesEnum_UNKNOWN).IsUnknown())
 }


### PR DESCRIPTION
## Before this PR 
Enums with no values would always return `false` for `IsUnknown`, however by definition there are no known variants of the enum if none are listed, thus `IsUnknown` should always return true.

Given the following conjure enum with no values
```yaml
types:
  definitions:
    objects:
      EmptySliceDeclFix:
        values: []
```

The current generated code is as follows:

```go
// IsUnknown returns false for all known variants of EmptySliceDeclFix and true otherwise.
func (e EmptySliceDeclFix) IsUnknown() bool {
	switch e.val {
	default:
		return false
	}
	return true
}
```

After this change the code becomes:
```go
// IsUnknown returns false for all known variants of EmptySliceDeclFix and true otherwise.
func (e EmptySliceDeclFix) IsUnknown() bool {
	return true
}
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the IsUnknown generated code behavior to only return false for known variants
==COMMIT_MSG==

This fixes the behavior slightly to what I would consider _more correct_. As seen above, the previously generated code would always return `false` for the `IsUnknown` method. However, given that there are no known values for this enum, it seems more correct to always return `true` given there are no known variants that are allowed.


## Possible downsides?
- Behavior change for the `IsUnknown` function which may be dependent upon by consumers, although the previous behavior was incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/245)
<!-- Reviewable:end -->
