### PR TITLE
Fix: Fix code generation of request param parsing for external types

### DIFF
--- a/changelog/@unreleased/pr-248.v2.yml
+++ b/changelog/@unreleased/pr-248.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Fix code generation of request param parsing for external types.
+    Fixes: #247
+  links:
+  - https://github.com/palantir/conjure-go/pull/248

--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -383,6 +383,8 @@ func astForDecodeHTTPParamInternal(methodBody *jen.Group, argName string, argTyp
 		)
 	case *types.Map, *types.ObjectType, *types.UnionType:
 		panic(fmt.Sprintf("unsupported complex type for http param %v", argType))
+	case *types.External:
+		astForDecodeHTTPParamInternal(methodBody, argName, typVal.Fallback, outVarName, inStrExpr, depth+1)
 	default:
 		panic(fmt.Sprintf("unrecognized type %v", argType))
 	}

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -35,6 +35,10 @@ type TestServiceClient interface {
 	QueryParamListSafeLong(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []safelong.SafeLong) error
 	QueryParamListString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []string) error
 	QueryParamListUuid(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg []uuid.UUID) error
+	QueryParamExternalString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg string) error
+	QueryParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg int) error
+	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
+	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
 	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
@@ -310,6 +314,60 @@ func (c *testServiceClient) QueryParamListUuid(ctx context.Context, authHeader b
 	return nil
 }
 
+func (c *testServiceClient) QueryParamExternalString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg string) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("QueryParamExternalString"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
+	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
+	requestParams = append(requestParams, httpclient.WithPathf("/externalStringQueryVar"))
+	queryParams := make(url.Values)
+	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
+	if _, err := c.client.Do(ctx, requestParams...); err != nil {
+		return werror.WrapWithContextParams(ctx, err, "queryParamExternalString failed")
+	}
+	return nil
+}
+
+func (c *testServiceClient) QueryParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg int) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("QueryParamExternalInteger"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("GET"))
+	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
+	requestParams = append(requestParams, httpclient.WithPathf("/externalIntegerQueryVar"))
+	queryParams := make(url.Values)
+	queryParams.Set("myQueryParam1", fmt.Sprint(myQueryParam1Arg))
+	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
+	if _, err := c.client.Do(ctx, requestParams...); err != nil {
+		return werror.WrapWithContextParams(ctx, err, "queryParamExternalInteger failed")
+	}
+	return nil
+}
+
+func (c *testServiceClient) PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamExternalString"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
+	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
+	requestParams = append(requestParams, httpclient.WithPathf("/externalStringPath/%s", url.PathEscape(fmt.Sprint(myPathParam1Arg))))
+	if _, err := c.client.Do(ctx, requestParams...); err != nil {
+		return werror.WrapWithContextParams(ctx, err, "pathParamExternalString failed")
+	}
+	return nil
+}
+
+func (c *testServiceClient) PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error {
+	var requestParams []httpclient.RequestParam
+	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamExternalInteger"))
+	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
+	requestParams = append(requestParams, httpclient.WithHeader("Authorization", fmt.Sprint("Bearer ", authHeader)))
+	requestParams = append(requestParams, httpclient.WithPathf("/externalIntegerPath/%s", url.PathEscape(fmt.Sprint(myPathParam1Arg))))
+	if _, err := c.client.Do(ctx, requestParams...); err != nil {
+		return werror.WrapWithContextParams(ctx, err, "pathParamExternalInteger failed")
+	}
+	return nil
+}
+
 func (c *testServiceClient) PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error) {
 	var defaultReturnVal CustomObject
 	var returnVal *CustomObject
@@ -480,6 +538,10 @@ type TestServiceClientWithAuth interface {
 	QueryParamListSafeLong(ctx context.Context, myQueryParam1Arg []safelong.SafeLong) error
 	QueryParamListString(ctx context.Context, myQueryParam1Arg []string) error
 	QueryParamListUuid(ctx context.Context, myQueryParam1Arg []uuid.UUID) error
+	QueryParamExternalString(ctx context.Context, myQueryParam1Arg string) error
+	QueryParamExternalInteger(ctx context.Context, myQueryParam1Arg int) error
+	PathParamExternalString(ctx context.Context, myPathParam1Arg string) error
+	PathParamExternalInteger(ctx context.Context, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
 	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
@@ -563,6 +625,22 @@ func (c *testServiceClientWithAuth) QueryParamListString(ctx context.Context, my
 
 func (c *testServiceClientWithAuth) QueryParamListUuid(ctx context.Context, myQueryParam1Arg []uuid.UUID) error {
 	return c.client.QueryParamListUuid(ctx, c.authHeader, myQueryParam1Arg)
+}
+
+func (c *testServiceClientWithAuth) QueryParamExternalString(ctx context.Context, myQueryParam1Arg string) error {
+	return c.client.QueryParamExternalString(ctx, c.authHeader, myQueryParam1Arg)
+}
+
+func (c *testServiceClientWithAuth) QueryParamExternalInteger(ctx context.Context, myQueryParam1Arg int) error {
+	return c.client.QueryParamExternalInteger(ctx, c.authHeader, myQueryParam1Arg)
+}
+
+func (c *testServiceClientWithAuth) PathParamExternalString(ctx context.Context, myPathParam1Arg string) error {
+	return c.client.PathParamExternalString(ctx, c.authHeader, myPathParam1Arg)
+}
+
+func (c *testServiceClientWithAuth) PathParamExternalInteger(ctx context.Context, myPathParam1Arg int) error {
+	return c.client.PathParamExternalInteger(ctx, c.authHeader, myPathParam1Arg)
 }
 
 func (c *testServiceClientWithAuth) PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error) {

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -6,6 +6,14 @@ types:
     OtherMarker:
       external:
         java: com.palantir.logsafe.OtherMarker
+    ExternalString:
+      base-type: string
+      external:
+        java: com.palantir.service.api.ExternalString
+    ExternalInteger:
+      base-type: integer
+      external:
+        java: com.palantir.rescue.api.ExternalInteger
   definitions:
     default-package: api
     objects:
@@ -119,6 +127,32 @@ services:
           myQueryParam1:
             type: list<uuid>
             param-type: query
+      queryParamExternalString:
+        http: GET /externalStringQueryVar
+        auth: header
+        args:
+          myQueryParam1:
+            type: ExternalString
+            param-type: query
+      queryParamExternalInteger:
+        http: GET /externalIntegerQueryVar
+        auth: header
+        args:
+          myQueryParam1:
+            type: ExternalInteger
+            param-type: query
+      pathParamExternalString:
+        http: POST /externalStringPath/{myPathParam1}
+        auth: header
+        args:
+          myPathParam1:
+            type: ExternalString
+      pathParamExternalInteger:
+        http: POST /externalIntegerPath/{myPathParam1}
+        auth: header
+        args:
+          myPathParam1:
+            type: ExternalInteger
       postPathParam:
         http: POST /path/{myPathParam1}/{myPathParam2}
         auth: header

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -363,3 +363,19 @@ func (t testServerImpl) GetOptionalBinary(ctx context.Context) (*io.ReadCloser, 
 func (t testServerImpl) Chan(ctx context.Context, varArg string, importArg map[string]string, typeArg string, returnArg safelong.SafeLong) error {
 	panic("implement me")
 }
+
+func (V testServerImpl) QueryParamExternalString(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg string) error {
+	panic("implement me")
+}
+
+func (V testServerImpl) QueryParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myQueryParam1Arg int) error {
+	panic("implement me")
+}
+
+func (V testServerImpl) PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error {
+	panic("implement me")
+}
+
+func (V testServerImpl) PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error {
+	panic("implement me")
+}


### PR DESCRIPTION
## Before this PR
Break in code-gen for APIs with external types.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix code generation of request param parsing for external types.
Fixes: #247 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/248)
<!-- Reviewable:end -->
