### PR TITLE
fix: Correctly handle binary return type with auth enabled

### DIFF
--- a/changelog/@unreleased/pr-250.v2.yml
+++ b/changelog/@unreleased/pr-250.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly handle binary return type with auth enabled.
+  links:
+  - https://github.com/palantir/conjure-go/pull/250

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -470,53 +470,57 @@ func astForTokenServiceStructDecl(serviceName string) *jen.Statement {
 	)
 }
 
+func astForTokenServiceEndpointMethodBody(methodBody *jen.Group, endpointDef *types.EndpointDefinition, hasAuth bool) {
+	if hasAuth {
+		if endpointDef.Returns != nil {
+			returnsType := *endpointDef.Returns
+			argType := returnsType.Code()
+			if returnsType.IsBinary() {
+				// special case: "binary" types resolve to []byte, but this indicates a streaming parameter when
+				// specified as the request argument of a service, so use "io.ReadCloser".
+				// If the type is optional<binary>, use "*io.ReadCloser".
+				if returnsType.IsOptional() {
+					argType = jen.Op("*").Add(snip.IOReadCloser())
+				} else {
+					argType = snip.IOReadCloser()
+				}
+			}
+			methodBody.Var().Id(defaultReturnValVar).Add(argType)
+		}
+		methodBody.List(jen.Id("token"), jen.Err()).Op(":=").Id(clientReceiverName).Dot(tokenProviderVar).Call(jen.Id("ctx"))
+		methodBody.If(jen.Err().Op("!=").Nil()).Block(jen.ReturnFunc(func(returns *jen.Group) {
+			if endpointDef.Returns != nil {
+				returns.Id(defaultReturnValVar)
+			}
+			returns.Err()
+		}))
+	}
+	methodBody.Return(jen.Id(clientReceiverName).Dot(clientStructFieldName).Dot(transforms.Export(endpointDef.EndpointName)).
+		CallFunc(func(args *jen.Group) {
+			args.Id("ctx")
+			if hasAuth {
+				args.Add(types.Bearertoken{}.Code()).Call(jen.Id("token"))
+			}
+			for _, paramDef := range endpointDef.Params {
+				args.Id(argNameTransform(paramDef.Name))
+			}
+		}),
+	)
+}
+
 func astForTokenServiceEndpointMethod(serviceName string, endpointDef *types.EndpointDefinition) *jen.Statement {
 	hasAuth := endpointDef.HeaderAuth || endpointDef.CookieAuth != nil
 	return jen.Func().
 		Params(jen.Id(clientReceiverName).Op("*").Id(withTokenProviderName(clientStructTypeName(serviceName)))).
 		Id(transforms.Export(endpointDef.EndpointName)).
 		ParamsFunc(func(args *jen.Group) {
-			astForEndpointArgsFunc(args, endpointDef, true, false)
+			astForEndpointArgsFunc(args, endpointDef, hasAuth, false)
 		}).
 		ParamsFunc(func(args *jen.Group) {
 			astForEndpointReturnsFunc(args, endpointDef)
 		}).
 		BlockFunc(func(methodBody *jen.Group) {
-			if hasAuth {
-				if endpointDef.Returns != nil {
-					returnsType := *endpointDef.Returns
-					argType := returnsType.Code()
-					if returnsType.IsBinary() {
-						// special case: "binary" types resolve to []byte, but this indicates a streaming parameter when
-						// specified as the request argument of a service, so use "io.ReadCloser".
-						// If the type is optional<binary>, use "*io.ReadCloser".
-						if returnsType.IsOptional() {
-							argType = jen.Op("*").Add(snip.IOReadCloser())
-						} else {
-							argType = snip.IOReadCloser()
-						}
-					}
-					methodBody.Var().Id(defaultReturnValVar).Add(argType)
-				}
-				methodBody.List(jen.Id("token"), jen.Err()).Op(":=").Id(clientReceiverName).Dot(tokenProviderVar).Call(jen.Id("ctx"))
-				methodBody.If(jen.Err().Op("!=").Nil()).Block(jen.ReturnFunc(func(returns *jen.Group) {
-					if endpointDef.Returns != nil {
-						returns.Id(defaultReturnValVar)
-					}
-					returns.Err()
-				}))
-			}
-			methodBody.Return(jen.Id(clientReceiverName).Dot(clientStructFieldName).Dot(transforms.Export(endpointDef.EndpointName)).
-				CallFunc(func(args *jen.Group) {
-					args.Id("ctx")
-					if hasAuth {
-						args.Add(types.Bearertoken{}.Code()).Call(jen.Id("token"))
-					}
-					for _, paramDef := range endpointDef.Params {
-						args.Id(argNameTransform(paramDef.Name))
-					}
-				}),
-			)
+			astForTokenServiceEndpointMethodBody(methodBody, endpointDef, hasAuth)
 		})
 }
 

--- a/integration_test/testgenerated/auth/auth-service.yml
+++ b/integration_test/testgenerated/auth/auth-service.yml
@@ -25,6 +25,12 @@ services:
       default:
         http: GET /default
         returns: string
+      binary:
+        http: GET /binary
+        returns: binary
+      binaryOptional:
+        http: GET /binaryOptional
+        returns: optional<binary>
   CookieAuthService:
     name: Cookie Auth Service
     package: api

--- a/integration_test/testgenerated/auth/auth_test.go
+++ b/integration_test/testgenerated/auth/auth_test.go
@@ -228,13 +228,13 @@ func (bothAuthImpl) Binary(ctx context.Context, authHeader bearertoken.Token) (i
 	if authHeader != testJWT {
 		return nil, errors.NewPermissionDenied()
 	}
-	return io.NopCloser(strings.NewReader(headerAuthAccepted)), nil
+	return ioutil.NopCloser(strings.NewReader(headerAuthAccepted)), nil
 }
 
 func (bothAuthImpl) BinaryOptional(ctx context.Context, authHeader bearertoken.Token) (*io.ReadCloser, error) {
 	if authHeader != testJWT {
 		return nil, errors.NewPermissionDenied()
 	}
-	r := io.NopCloser(strings.NewReader(headerAuthAccepted))
+	r := ioutil.NopCloser(strings.NewReader(headerAuthAccepted))
 	return &r, nil
 }

--- a/integration_test/testgenerated/auth/auth_test.go
+++ b/integration_test/testgenerated/auth/auth_test.go
@@ -16,6 +16,9 @@ package auth_test
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
@@ -79,7 +82,7 @@ func TestBothAuthClient(t *testing.T) {
 func TestHeaderAuthClient(t *testing.T) {
 	ctx := testutil.TestContext()
 	httpClient, cleanup := testutil.StartTestServer(t, func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
-		if err := api.RegisterRoutesBothAuthService(info.Router, bothAuthImpl{}); err != nil {
+		if err := api.RegisterRoutesHeaderAuthService(info.Router, bothAuthImpl{}); err != nil {
 			return nil, err
 		}
 		return nil, nil
@@ -90,15 +93,59 @@ func TestHeaderAuthClient(t *testing.T) {
 	tokenClient := api.NewHeaderAuthServiceClientWithTokenProvider(client, tokenProvider)
 
 	// test header auth calls
-	resp, err := client.Default(ctx, testJWT)
-	require.NoError(t, err)
-	assert.Equal(t, headerAuthAccepted, resp)
-	resp, err = authClient.Default(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, headerAuthAccepted, resp)
-	resp, err = tokenClient.Default(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, headerAuthAccepted, resp)
+	t.Run("default", func(t *testing.T) {
+		resp, err := client.Default(ctx, testJWT)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, resp)
+
+		resp, err = authClient.Default(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, resp)
+
+		resp, err = tokenClient.Default(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, resp)
+	})
+
+	t.Run("binary", func(t *testing.T) {
+		resp, err := client.Binary(ctx, testJWT)
+		require.NoError(t, err)
+		data, err := ioutil.ReadAll(resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+
+		resp, err = authClient.Binary(ctx)
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+
+		resp, err = tokenClient.Binary(ctx)
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+	})
+
+	t.Run("binary optional", func(t *testing.T) {
+		resp, err := client.BinaryOptional(ctx, testJWT)
+		require.NoError(t, err)
+		data, err := ioutil.ReadAll(*resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+
+		resp, err = authClient.BinaryOptional(ctx)
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(*resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+
+		resp, err = tokenClient.BinaryOptional(ctx)
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(*resp)
+		require.NoError(t, err)
+		assert.Equal(t, headerAuthAccepted, string(data))
+	})
 }
 
 func TestCookieAuthClient(t *testing.T) {
@@ -175,4 +222,19 @@ func (bothAuthImpl) WithArg(ctx context.Context, authHeader bearertoken.Token, a
 		return errors.NewPermissionDenied()
 	}
 	return nil
+}
+
+func (bothAuthImpl) Binary(ctx context.Context, authHeader bearertoken.Token) (io.ReadCloser, error) {
+	if authHeader != testJWT {
+		return nil, errors.NewPermissionDenied()
+	}
+	return io.NopCloser(strings.NewReader(headerAuthAccepted)), nil
+}
+
+func (bothAuthImpl) BinaryOptional(ctx context.Context, authHeader bearertoken.Token) (*io.ReadCloser, error) {
+	if authHeader != testJWT {
+		return nil, errors.NewPermissionDenied()
+	}
+	r := io.NopCloser(strings.NewReader(headerAuthAccepted))
+	return &r, nil
 }

--- a/integration_test/testgenerated/binary/binary_test.go
+++ b/integration_test/testgenerated/binary/binary_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"github.com/palantir/pkg/bearertoken"
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
@@ -56,7 +55,7 @@ func TestBytes(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("Binary", func(t *testing.T) {
-		resp, err := client.Binary(ctx, "", func() io.ReadCloser {
+		resp, err := client.Binary(ctx, func() io.ReadCloser {
 			return ioutil.NopCloser(bytes.NewReader(randBytes))
 		})
 		require.NoError(t, err)
@@ -149,7 +148,7 @@ func (b binaryServer) BinaryAlias(ctx context.Context, bodyArg io.ReadCloser) (i
 	return resp, nil
 }
 
-func (b binaryServer) Binary(ctx context.Context, authHeader bearertoken.Token, bodyArg io.ReadCloser) (io.ReadCloser, error) {
+func (b binaryServer) Binary(ctx context.Context, bodyArg io.ReadCloser) (io.ReadCloser, error) {
 	body, err := ioutil.ReadAll(bodyArg)
 	if err != nil {
 		return nil, err

--- a/integration_test/testgenerated/binary/binary_test.go
+++ b/integration_test/testgenerated/binary/binary_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"github.com/palantir/pkg/bearertoken"
 	"io"
 	"io/ioutil"
 	"net/http/httptest"
@@ -55,7 +56,7 @@ func TestBytes(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 	t.Run("Binary", func(t *testing.T) {
-		resp, err := client.Binary(ctx, func() io.ReadCloser {
+		resp, err := client.Binary(ctx, "", func() io.ReadCloser {
 			return ioutil.NopCloser(bytes.NewReader(randBytes))
 		})
 		require.NoError(t, err)
@@ -148,7 +149,7 @@ func (b binaryServer) BinaryAlias(ctx context.Context, bodyArg io.ReadCloser) (i
 	return resp, nil
 }
 
-func (b binaryServer) Binary(ctx context.Context, bodyArg io.ReadCloser) (io.ReadCloser, error) {
+func (b binaryServer) Binary(ctx context.Context, authHeader bearertoken.Token, bodyArg io.ReadCloser) (io.ReadCloser, error) {
 	body, err := ioutil.ReadAll(bodyArg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Before this PR
See updated [](integration_test/testgenerated/auth/auth-service.yml) file for an example of a Conjure definition that results in generated code that fails to compile. The error looks like this:

```
services.conjure.go:1:1: cannot use defaultReturnVal (type []byte) as type io.ReadCloser in return argument:
	[]byte does not implement io.ReadCloser (missing Close method)
```

The bug is only reproducible for Conjure endpoints that return a `binary` or `optional<binary>` type and have auth enabled.

I think it was introduced in https://github.com/palantir/conjure-go/releases/tag/v6.6.0 or later, as previous version didn't have this bug.

## After this PR
==COMMIT_MSG==
Correctly handle binary return type with auth enabled.
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/250)
<!-- Reviewable:end -->
