### PR TITLE
Fix: Generate alias encoding methods based on the external fallback type

### DIFF
--- a/changelog/@unreleased/pr-252.v2.yml
+++ b/changelog/@unreleased/pr-252.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Generate alias encoding methods based on the external fallback type
+    Fixes #251
+  links:
+  - https://github.com/palantir/conjure-go/pull/252

--- a/conjure/aliaswriter.go
+++ b/conjure/aliaswriter.go
@@ -113,6 +113,8 @@ func isSimpleAliasType(t types.Type) bool {
 		return isSimpleAliasType(v.Item)
 	case *types.AliasType:
 		return isSimpleAliasType(v.Item)
+	case *types.External:
+		return isSimpleAliasType(v.Fallback)
 	default:
 		return false
 	}

--- a/integration_test/testgenerated/objects/api/aliases.conjure.go
+++ b/integration_test/testgenerated/objects/api/aliases.conjure.go
@@ -46,8 +46,42 @@ func (a *BinaryAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return safejson.Unmarshal(jsonBytes, *&a)
 }
 
+type ListLongAlias []interface{}
+type LongAlias interface{}
+type MapLongAlias map[string]interface{}
 type MapStringAny map[string]interface{}
 type MapStringAnyAlias map[string]AnyAlias
+type MapUuidLongAlias map[uuid.UUID]interface{}
+
+func (a MapUuidLongAlias) MarshalJSON() ([]byte, error) {
+	return safejson.Marshal(map[uuid.UUID]interface{}(a))
+}
+
+func (a *MapUuidLongAlias) UnmarshalJSON(data []byte) error {
+	var rawMapUuidLongAlias map[uuid.UUID]interface{}
+	if err := safejson.Unmarshal(data, &rawMapUuidLongAlias); err != nil {
+		return err
+	}
+	*a = MapUuidLongAlias(rawMapUuidLongAlias)
+	return nil
+}
+
+func (a MapUuidLongAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+
+func (a *MapUuidLongAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+
 type NestedAlias1 NestedAlias2
 type NestedAlias2 NestedAlias3
 type NestedAlias3 struct {

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -1,4 +1,9 @@
 types:
+  imports:
+    ExternalLong:
+      base-type: any
+      external:
+        java: java.lang.Long
   definitions:
     default-package: api
     objects:
@@ -91,3 +96,13 @@ types:
         fields:
           mapStringAny: MapStringAny
           mapStringAnyAlias: MapStringAnyAlias
+      # *LongAlias types below contain simple types and should not generate encoding methods
+      LongAlias:
+        alias: ExternalLong
+      ListLongAlias:
+        alias: list<ExternalLong>
+      MapLongAlias:
+        alias: map<string,ExternalLong>
+      # uuid is not a simple type, so encoding methods should be generated
+      MapUuidLongAlias:
+        alias: map<uuid,ExternalLong>


### PR DESCRIPTION
## Before this PR 
See #251 for more information

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Generate alias encoding methods based on the external fallback type
Fixes #251
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/252)
<!-- Reviewable:end -->
