### PR TITLE
Improvement: Add verbose mode to generated CLIs

### DIFF
--- a/changelog/@unreleased/pr-305.v2.yml
+++ b/changelog/@unreleased/pr-305.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add verbose mode to generated CLIs
+  links:
+  - https://github.com/palantir/conjure-go/pull/305

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -73,7 +73,8 @@ var (
 	FmtSprint           = jen.Qual("fmt", "Sprint").Clone
 	FmtSprintf          = jen.Qual("fmt", "Sprintf").Clone
 	IOReadCloser        = jen.Qual("io", "ReadCloser").Clone
-	IOCopy              = jen.Qual("io", "Copy").Clone()
+	IOCopy              = jen.Qual("io", "Copy").Clone
+	IODiscard           = jen.Qual("io", "Discard").Clone
 	JSONMarshaler       = jen.Qual("encoding/json", "Marshaler").Clone
 	JSONUnmarshaler     = jen.Qual("encoding/json", "Unmarshaler").Clone
 	MathIsInf           = jen.Qual("math", "IsInf").Clone
@@ -178,12 +179,13 @@ var (
 	WerrorWrapContext     = jen.Qual(pal+"witchcraft-go-error", "WrapWithContextParams").Clone
 
 	WGLLogSetDefaultLoggerProvider = jen.Qual(wgl+"wlog", "SetDefaultLoggerProvider").Clone
+	WGLLogNoopLoggerProvider       = jen.Qual(wgl+"wlog", "NewNoopLoggerProvider").Clone
 	WGLLogDebugLevel               = jen.Qual(wgl+"wlog", "DebugLevel").Clone
 	WGLWlogZapLoggerProvider       = jen.Qual(wgl+"wlog-zap", "LoggerProvider").Clone
 	WGLSvc1logWithLogger           = jen.Qual(wgl+"wlog/svclog/svc1log", "WithLogger").Clone
 	WGLSvc1logNew                  = jen.Qual(wgl+"wlog/svclog/svc1log", "New").Clone
 	WGLTrc1logWithLogger           = jen.Qual(wgl+"wlog/trclog/trc1log", "WithLogger").Clone
-	WGLTrc1logDefaultLogger        = jen.Qual(wgl+"wlog/trclog/trc1log", "DefaultLogger").Clone
+	WGLTrc1logNewLogger            = jen.Qual(wgl+"wlog/trclog/trc1log", "New").Clone
 	WGLEvt2logWithLogger           = jen.Qual(wgl+"wlog/evtlog/evt2log", "WithLogger").Clone
 	WGLEvt2logNew                  = jen.Qual(wgl+"wlog/evtlog/evt2log", "New").Clone
 	WGTContextWithTracer           = jen.Qual(pal+"witchcraft-go-tracing/wtracing", "ContextWithTracer").Clone

--- a/integration_test/testgenerated/auth/api/cli.conjure.go
+++ b/integration_test/testgenerated/auth/api/cli.conjure.go
@@ -65,6 +65,7 @@ func NewBothAuthServiceCLICommandWithClientProvider(clientProvider CLIBothAuthSe
 		Use:   "bothAuthService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := BothAuthServiceCLICommand{clientProvider: clientProvider}
 
@@ -104,8 +105,8 @@ func NewBothAuthServiceCLICommandWithClientProvider(clientProvider CLIBothAuthSe
 }
 
 func (c BothAuthServiceCLICommand) bothAuthService_Default_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -127,8 +128,8 @@ func (c BothAuthServiceCLICommand) bothAuthService_Default_CmdRun(cmd *cobra.Com
 }
 
 func (c BothAuthServiceCLICommand) bothAuthService_Cookie_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -145,8 +146,8 @@ func (c BothAuthServiceCLICommand) bothAuthService_Cookie_CmdRun(cmd *cobra.Comm
 }
 
 func (c BothAuthServiceCLICommand) bothAuthService_None_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -155,8 +156,8 @@ func (c BothAuthServiceCLICommand) bothAuthService_None_CmdRun(cmd *cobra.Comman
 }
 
 func (c BothAuthServiceCLICommand) bothAuthService_WithArg_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -219,6 +220,7 @@ func NewCookieAuthServiceCLICommandWithClientProvider(clientProvider CLICookieAu
 		Use:   "cookieAuthService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := CookieAuthServiceCLICommand{clientProvider: clientProvider}
 
@@ -234,8 +236,8 @@ func NewCookieAuthServiceCLICommandWithClientProvider(clientProvider CLICookieAu
 }
 
 func (c CookieAuthServiceCLICommand) cookieAuthService_Cookie_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -289,6 +291,7 @@ func NewHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLIHeaderAu
 		Use:   "headerAuthService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := HeaderAuthServiceCLICommand{clientProvider: clientProvider}
 
@@ -320,8 +323,8 @@ func NewHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLIHeaderAu
 }
 
 func (c HeaderAuthServiceCLICommand) headerAuthService_Default_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -343,8 +346,8 @@ func (c HeaderAuthServiceCLICommand) headerAuthService_Default_CmdRun(cmd *cobra
 }
 
 func (c HeaderAuthServiceCLICommand) headerAuthService_Binary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -369,8 +372,8 @@ func (c HeaderAuthServiceCLICommand) headerAuthService_Binary_CmdRun(cmd *cobra.
 }
 
 func (c HeaderAuthServiceCLICommand) headerAuthService_BinaryOptional_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -436,6 +439,7 @@ func NewSomeHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLISome
 		Use:   "someHeaderAuthService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := SomeHeaderAuthServiceCLICommand{clientProvider: clientProvider}
 
@@ -458,8 +462,8 @@ func NewSomeHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLISome
 }
 
 func (c SomeHeaderAuthServiceCLICommand) someHeaderAuthService_Default_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -481,8 +485,8 @@ func (c SomeHeaderAuthServiceCLICommand) someHeaderAuthService_Default_CmdRun(cm
 }
 
 func (c SomeHeaderAuthServiceCLICommand) someHeaderAuthService_None_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -508,8 +512,12 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 	return conf, nil
 }
 
-func getCLIContext() context.Context {
+func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	verbose, err := flags.GetBool("verbose")
+	if !verbose || err != nil {
+		return ctx
+	}
 	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
 	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
 	traceLogger := trc1log.DefaultLogger()

--- a/integration_test/testgenerated/auth/api/cli.conjure.go
+++ b/integration_test/testgenerated/auth/api/cli.conjure.go
@@ -514,15 +514,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx

--- a/integration_test/testgenerated/binary/api/cli.conjure.go
+++ b/integration_test/testgenerated/binary/api/cli.conjure.go
@@ -234,15 +234,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx

--- a/integration_test/testgenerated/cli/api/cli.conjure.go
+++ b/integration_test/testgenerated/cli/api/cli.conjure.go
@@ -74,6 +74,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Use:   "testService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}
 
@@ -232,8 +233,8 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 }
 
 func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -250,8 +251,8 @@ func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []s
 }
 
 func (c TestServiceCLICommand) testService_EchoStrings_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -283,8 +284,8 @@ func (c TestServiceCLICommand) testService_EchoStrings_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_EchoCustomObject_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -315,8 +316,8 @@ func (c TestServiceCLICommand) testService_EchoCustomObject_CmdRun(cmd *cobra.Co
 }
 
 func (c TestServiceCLICommand) testService_EchoOptionalAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -349,8 +350,8 @@ func (c TestServiceCLICommand) testService_EchoOptionalAlias_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_EchoOptionalListAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -381,8 +382,8 @@ func (c TestServiceCLICommand) testService_EchoOptionalListAlias_CmdRun(cmd *cob
 }
 
 func (c TestServiceCLICommand) testService_GetPathParam_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -408,8 +409,8 @@ func (c TestServiceCLICommand) testService_GetPathParam_CmdRun(cmd *cobra.Comman
 }
 
 func (c TestServiceCLICommand) testService_GetListBoolean_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -441,8 +442,8 @@ func (c TestServiceCLICommand) testService_GetListBoolean_CmdRun(cmd *cobra.Comm
 }
 
 func (c TestServiceCLICommand) testService_PutMapStringString_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -474,8 +475,8 @@ func (c TestServiceCLICommand) testService_PutMapStringString_CmdRun(cmd *cobra.
 }
 
 func (c TestServiceCLICommand) testService_PutMapStringAny_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -507,8 +508,8 @@ func (c TestServiceCLICommand) testService_PutMapStringAny_CmdRun(cmd *cobra.Com
 }
 
 func (c TestServiceCLICommand) testService_GetDateTime_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -534,8 +535,8 @@ func (c TestServiceCLICommand) testService_GetDateTime_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_GetDouble_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -566,8 +567,8 @@ func (c TestServiceCLICommand) testService_GetDouble_CmdRun(cmd *cobra.Command, 
 }
 
 func (c TestServiceCLICommand) testService_GetRid_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -593,8 +594,8 @@ func (c TestServiceCLICommand) testService_GetRid_CmdRun(cmd *cobra.Command, _ [
 }
 
 func (c TestServiceCLICommand) testService_GetSafeLong_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -625,8 +626,8 @@ func (c TestServiceCLICommand) testService_GetSafeLong_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_GetUuid_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -652,8 +653,8 @@ func (c TestServiceCLICommand) testService_GetUuid_CmdRun(cmd *cobra.Command, _ 
 }
 
 func (c TestServiceCLICommand) testService_GetBinary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -670,8 +671,8 @@ func (c TestServiceCLICommand) testService_GetBinary_CmdRun(cmd *cobra.Command, 
 }
 
 func (c TestServiceCLICommand) testService_GetOptionalBinary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -692,8 +693,8 @@ func (c TestServiceCLICommand) testService_GetOptionalBinary_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_GetReserved_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -720,8 +721,8 @@ func (c TestServiceCLICommand) testService_GetReserved_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_Chan_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -826,8 +827,12 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 	return conf, nil
 }
 
-func getCLIContext() context.Context {
+func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	verbose, err := flags.GetBool("verbose")
+	if !verbose || err != nil {
+		return ctx
+	}
 	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
 	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
 	traceLogger := trc1log.DefaultLogger()

--- a/integration_test/testgenerated/client/api/cli.conjure.go
+++ b/integration_test/testgenerated/client/api/cli.conjure.go
@@ -335,15 +335,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx

--- a/integration_test/testgenerated/client/api/cli.conjure.go
+++ b/integration_test/testgenerated/client/api/cli.conjure.go
@@ -67,6 +67,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Use:   "testService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}
 
@@ -142,8 +143,8 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 }
 
 func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -152,8 +153,8 @@ func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []s
 }
 
 func (c TestServiceCLICommand) testService_PathParam_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -171,8 +172,8 @@ func (c TestServiceCLICommand) testService_PathParam_CmdRun(cmd *cobra.Command, 
 }
 
 func (c TestServiceCLICommand) testService_PathParamAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -190,8 +191,8 @@ func (c TestServiceCLICommand) testService_PathParamAlias_CmdRun(cmd *cobra.Comm
 }
 
 func (c TestServiceCLICommand) testService_PathParamRid_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -212,8 +213,8 @@ func (c TestServiceCLICommand) testService_PathParamRid_CmdRun(cmd *cobra.Comman
 }
 
 func (c TestServiceCLICommand) testService_PathParamRidAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -235,8 +236,8 @@ func (c TestServiceCLICommand) testService_PathParamRidAlias_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_Bytes_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -255,8 +256,8 @@ func (c TestServiceCLICommand) testService_Bytes_CmdRun(cmd *cobra.Command, _ []
 }
 
 func (c TestServiceCLICommand) testService_Binary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -273,8 +274,8 @@ func (c TestServiceCLICommand) testService_Binary_CmdRun(cmd *cobra.Command, _ [
 }
 
 func (c TestServiceCLICommand) testService_MaybeBinary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -295,8 +296,8 @@ func (c TestServiceCLICommand) testService_MaybeBinary_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_Query_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -332,8 +333,12 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 	return conf, nil
 }
 
-func getCLIContext() context.Context {
+func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	verbose, err := flags.GetBool("verbose")
+	if !verbose || err != nil {
+		return ctx
+	}
 	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
 	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
 	traceLogger := trc1log.DefaultLogger()

--- a/integration_test/testgenerated/post/api/cli.conjure.go
+++ b/integration_test/testgenerated/post/api/cli.conjure.go
@@ -63,6 +63,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Use:   "testService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}
 
@@ -78,8 +79,8 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 }
 
 func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -119,8 +120,12 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 	return conf, nil
 }
 
-func getCLIContext() context.Context {
+func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	verbose, err := flags.GetBool("verbose")
+	if !verbose || err != nil {
+		return ctx
+	}
 	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
 	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
 	traceLogger := trc1log.DefaultLogger()

--- a/integration_test/testgenerated/post/api/cli.conjure.go
+++ b/integration_test/testgenerated/post/api/cli.conjure.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
@@ -122,15 +123,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx

--- a/integration_test/testgenerated/queryparam/api/cli.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/cli.conjure.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 
@@ -175,15 +176,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -74,6 +74,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Use:   "testService",
 	}
 	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}
 
@@ -338,8 +339,8 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 }
 
 func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -356,8 +357,8 @@ func (c TestServiceCLICommand) testService_Echo_CmdRun(cmd *cobra.Command, _ []s
 }
 
 func (c TestServiceCLICommand) testService_EchoStrings_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -389,8 +390,8 @@ func (c TestServiceCLICommand) testService_EchoStrings_CmdRun(cmd *cobra.Command
 }
 
 func (c TestServiceCLICommand) testService_EchoCustomObject_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -421,8 +422,8 @@ func (c TestServiceCLICommand) testService_EchoCustomObject_CmdRun(cmd *cobra.Co
 }
 
 func (c TestServiceCLICommand) testService_EchoOptionalAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -455,8 +456,8 @@ func (c TestServiceCLICommand) testService_EchoOptionalAlias_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_EchoOptionalListAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -487,8 +488,8 @@ func (c TestServiceCLICommand) testService_EchoOptionalListAlias_CmdRun(cmd *cob
 }
 
 func (c TestServiceCLICommand) testService_GetPathParam_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -514,8 +515,8 @@ func (c TestServiceCLICommand) testService_GetPathParam_CmdRun(cmd *cobra.Comman
 }
 
 func (c TestServiceCLICommand) testService_GetPathParamAlias_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -541,8 +542,8 @@ func (c TestServiceCLICommand) testService_GetPathParamAlias_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_QueryParamList_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -572,8 +573,8 @@ func (c TestServiceCLICommand) testService_QueryParamList_CmdRun(cmd *cobra.Comm
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListBoolean_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -603,8 +604,8 @@ func (c TestServiceCLICommand) testService_QueryParamListBoolean_CmdRun(cmd *cob
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListDateTime_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -634,8 +635,8 @@ func (c TestServiceCLICommand) testService_QueryParamListDateTime_CmdRun(cmd *co
 }
 
 func (c TestServiceCLICommand) testService_QueryParamSetDateTime_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -675,8 +676,8 @@ func (c TestServiceCLICommand) testService_QueryParamSetDateTime_CmdRun(cmd *cob
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListDouble_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -706,8 +707,8 @@ func (c TestServiceCLICommand) testService_QueryParamListDouble_CmdRun(cmd *cobr
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListInteger_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -737,8 +738,8 @@ func (c TestServiceCLICommand) testService_QueryParamListInteger_CmdRun(cmd *cob
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListRid_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -768,8 +769,8 @@ func (c TestServiceCLICommand) testService_QueryParamListRid_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListSafeLong_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -799,8 +800,8 @@ func (c TestServiceCLICommand) testService_QueryParamListSafeLong_CmdRun(cmd *co
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListString_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -830,8 +831,8 @@ func (c TestServiceCLICommand) testService_QueryParamListString_CmdRun(cmd *cobr
 }
 
 func (c TestServiceCLICommand) testService_QueryParamListUuid_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -861,8 +862,8 @@ func (c TestServiceCLICommand) testService_QueryParamListUuid_CmdRun(cmd *cobra.
 }
 
 func (c TestServiceCLICommand) testService_QueryParamExternalString_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -888,8 +889,8 @@ func (c TestServiceCLICommand) testService_QueryParamExternalString_CmdRun(cmd *
 }
 
 func (c TestServiceCLICommand) testService_QueryParamExternalInteger_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -918,8 +919,8 @@ func (c TestServiceCLICommand) testService_QueryParamExternalInteger_CmdRun(cmd 
 }
 
 func (c TestServiceCLICommand) testService_PathParamExternalString_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -945,8 +946,8 @@ func (c TestServiceCLICommand) testService_PathParamExternalString_CmdRun(cmd *c
 }
 
 func (c TestServiceCLICommand) testService_PathParamExternalInteger_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -975,8 +976,8 @@ func (c TestServiceCLICommand) testService_PathParamExternalInteger_CmdRun(cmd *
 }
 
 func (c TestServiceCLICommand) testService_PostPathParam_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1129,8 +1130,8 @@ func (c TestServiceCLICommand) testService_PostPathParam_CmdRun(cmd *cobra.Comma
 }
 
 func (c TestServiceCLICommand) testService_PostSafeParams_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1259,8 +1260,8 @@ func (c TestServiceCLICommand) testService_PostSafeParams_CmdRun(cmd *cobra.Comm
 }
 
 func (c TestServiceCLICommand) testService_Bytes_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1279,8 +1280,8 @@ func (c TestServiceCLICommand) testService_Bytes_CmdRun(cmd *cobra.Command, _ []
 }
 
 func (c TestServiceCLICommand) testService_GetBinary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1297,8 +1298,8 @@ func (c TestServiceCLICommand) testService_GetBinary_CmdRun(cmd *cobra.Command, 
 }
 
 func (c TestServiceCLICommand) testService_GetOptionalBinary_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1319,8 +1320,8 @@ func (c TestServiceCLICommand) testService_GetOptionalBinary_CmdRun(cmd *cobra.C
 }
 
 func (c TestServiceCLICommand) testService_Chan_CmdRun(cmd *cobra.Command, _ []string) error {
-	ctx := getCLIContext()
 	flags := cmd.Flags()
+	ctx := getCLIContext(flags)
 	client, err := c.clientProvider.Get(ctx, flags)
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to initialize client")
@@ -1425,8 +1426,12 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 	return conf, nil
 }
 
-func getCLIContext() context.Context {
+func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	verbose, err := flags.GetBool("verbose")
+	if !verbose || err != nil {
+		return ctx
+	}
 	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
 	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
 	traceLogger := trc1log.DefaultLogger()

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -1428,15 +1428,18 @@ func loadCLIConfig(ctx context.Context, flags *pflag.FlagSet) (CLIConfig, error)
 
 func getCLIContext(flags *pflag.FlagSet) context.Context {
 	ctx := context.Background()
+	logProvider := wlog.NewNoopLoggerProvider()
+	logWriter := io.Discard
 	verbose, err := flags.GetBool("verbose")
-	if !verbose || err != nil {
-		return ctx
+	if verbose && err == nil {
+		logProvider = wlogzap.LoggerProvider()
+		logWriter = os.Stdout
 	}
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	ctx = svc1log.WithLogger(ctx, svc1log.New(os.Stdout, wlog.DebugLevel))
-	traceLogger := trc1log.DefaultLogger()
+	wlog.SetDefaultLoggerProvider(logProvider)
+	ctx = svc1log.WithLogger(ctx, svc1log.New(logWriter, wlog.DebugLevel))
+	traceLogger := trc1log.New(logWriter)
 	ctx = trc1log.WithLogger(ctx, traceLogger)
-	ctx = evt2log.WithLogger(ctx, evt2log.New(os.Stdout))
+	ctx = evt2log.WithLogger(ctx, evt2log.New(logWriter))
 	tracer, err := wzipkin.NewTracer(traceLogger)
 	if err != nil {
 		return ctx


### PR DESCRIPTION

==COMMIT_MSG==
Add verbose mode to generated CLIs
==COMMIT_MSG==

* For generated CLI commands, only initialize a logging context if the `-v` or `--verbose` flag is set. This keeps output clean so that it can be piped through to other commands or scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/305)
<!-- Reviewable:end -->
