### PR TITLE
Fix: Fix typo in default generated CLI conf path

### DIFF
--- a/changelog/@unreleased/pr-312.v2.yml
+++ b/changelog/@unreleased/pr-312.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix typo in default generated CLI conf path
+  links:
+  - https://github.com/palantir/conjure-go/pull/312

--- a/conjure/cliwriter.go
+++ b/conjure/cliwriter.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	cliConfigTypeName     = "CLIConfig"
-	defaultConfigFilePath = "../var/conf/configuration.yml"
+	defaultConfigFilePath = "./var/conf/configuration.yml"
 
 	loadConfigFuncName    = "loadCLIConfig"
 	getCLIContextFuncName = "getCLIContext"

--- a/conjure/cliwriter.go
+++ b/conjure/cliwriter.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	cliConfigTypeName     = "CLIConfig"
-	defaultConfigFilePath = "./var/conf/configuration.yml"
+	defaultConfigFilePath = "var/conf/configuration.yml"
 
 	loadConfigFuncName    = "loadCLIConfig"
 	getCLIContextFuncName = "getCLIContext"

--- a/integration_test/testgenerated/auth/api/cli.conjure.go
+++ b/integration_test/testgenerated/auth/api/cli.conjure.go
@@ -64,7 +64,7 @@ func NewBothAuthServiceCLICommandWithClientProvider(clientProvider CLIBothAuthSe
 		Short: "Runs commands on the BothAuthService",
 		Use:   "bothAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := BothAuthServiceCLICommand{clientProvider: clientProvider}
@@ -219,7 +219,7 @@ func NewCookieAuthServiceCLICommandWithClientProvider(clientProvider CLICookieAu
 		Short: "Runs commands on the CookieAuthService",
 		Use:   "cookieAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := CookieAuthServiceCLICommand{clientProvider: clientProvider}
@@ -290,7 +290,7 @@ func NewHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLIHeaderAu
 		Short: "Runs commands on the HeaderAuthService",
 		Use:   "headerAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := HeaderAuthServiceCLICommand{clientProvider: clientProvider}
@@ -438,7 +438,7 @@ func NewSomeHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLISome
 		Short: "Runs commands on the SomeHeaderAuthService",
 		Use:   "someHeaderAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := SomeHeaderAuthServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/auth/api/cli.conjure.go
+++ b/integration_test/testgenerated/auth/api/cli.conjure.go
@@ -64,7 +64,7 @@ func NewBothAuthServiceCLICommandWithClientProvider(clientProvider CLIBothAuthSe
 		Short: "Runs commands on the BothAuthService",
 		Use:   "bothAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := BothAuthServiceCLICommand{clientProvider: clientProvider}
@@ -219,7 +219,7 @@ func NewCookieAuthServiceCLICommandWithClientProvider(clientProvider CLICookieAu
 		Short: "Runs commands on the CookieAuthService",
 		Use:   "cookieAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := CookieAuthServiceCLICommand{clientProvider: clientProvider}
@@ -290,7 +290,7 @@ func NewHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLIHeaderAu
 		Short: "Runs commands on the HeaderAuthService",
 		Use:   "headerAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := HeaderAuthServiceCLICommand{clientProvider: clientProvider}
@@ -438,7 +438,7 @@ func NewSomeHeaderAuthServiceCLICommandWithClientProvider(clientProvider CLISome
 		Short: "Runs commands on the SomeHeaderAuthService",
 		Use:   "someHeaderAuthService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := SomeHeaderAuthServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/binary/api/cli.conjure.go
+++ b/integration_test/testgenerated/binary/api/cli.conjure.go
@@ -68,7 +68,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/binary/api/cli.conjure.go
+++ b/integration_test/testgenerated/binary/api/cli.conjure.go
@@ -68,7 +68,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/cli/api/cli.conjure.go
+++ b/integration_test/testgenerated/cli/api/cli.conjure.go
@@ -75,7 +75,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/cli/api/cli.conjure.go
+++ b/integration_test/testgenerated/cli/api/cli.conjure.go
@@ -75,7 +75,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/client/api/cli.conjure.go
+++ b/integration_test/testgenerated/client/api/cli.conjure.go
@@ -66,7 +66,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/client/api/cli.conjure.go
+++ b/integration_test/testgenerated/client/api/cli.conjure.go
@@ -66,7 +66,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/post/api/cli.conjure.go
+++ b/integration_test/testgenerated/post/api/cli.conjure.go
@@ -63,7 +63,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/post/api/cli.conjure.go
+++ b/integration_test/testgenerated/post/api/cli.conjure.go
@@ -63,7 +63,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/queryparam/api/cli.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/cli.conjure.go
@@ -68,7 +68,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/queryparam/api/cli.conjure.go
+++ b/integration_test/testgenerated/queryparam/api/cli.conjure.go
@@ -68,7 +68,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -75,7 +75,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "../var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -75,7 +75,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 		Short: "Runs commands on the TestService",
 		Use:   "testService",
 	}
-	rootCmd.PersistentFlags().String("conf", "./var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
+	rootCmd.PersistentFlags().String("conf", "var/conf/configuration.yml", "The configuration file is optional. The default path is ./var/conf/configuration.yml.")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enables verbose mode for debugging client connections.")
 
 	cliCommand := TestServiceCLICommand{clientProvider: clientProvider}


### PR DESCRIPTION

==COMMIT_MSG==
Fix typo in default generated CLI conf path
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/312)
<!-- Reviewable:end -->
