### PR TITLE
fix: Use log safety from type definition in endpoint registration

### DIFF
--- a/changelog/@unreleased/pr-403.v2.yml
+++ b/changelog/@unreleased/pr-403.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Use log safety from type definition in endpoint registration
+  description: Use log safety from type definition in endpoint registration. Add DoNotLog marker.
   links:
   - https://github.com/palantir/conjure-go/pull/403

--- a/changelog/@unreleased/pr-403.v2.yml
+++ b/changelog/@unreleased/pr-403.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use log safety from type definition in endpoint registration
+  links:
+  - https://github.com/palantir/conjure-go/pull/403

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -60,14 +60,12 @@ func NewConjureDefinition(outputBaseDir string, def spec.ConjureDefinition) (*Co
 	for _, typeDef := range def.Types {
 		if err := typeDef.AcceptFuncs(
 			func(def spec.AliasDefinition) error {
-				if def.Safety != nil {
-					logSafetyWarning()
-				}
 				alias := &AliasType{
 					Docs:       Docs(transforms.Documentation(def.Docs)),
 					Item:       names.GetBySpec(def.Alias),
 					conjurePkg: def.TypeName.Package,
 					importPath: paths.conjurePkgToGoPkg(def.TypeName.Package),
+					safety:     def.Safety,
 					Name:       def.TypeName.Name,
 				}
 				names.put(def.TypeName, alias)

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -1337,7 +1337,7 @@ func (c TestServiceCLICommand) testService_PostSafeParams_CmdRun(cmd *cobra.Comm
 	if myPathParam1Raw == "" {
 		return werror.ErrorWithContextParams(ctx, "myPathParam1 is a required argument")
 	}
-	myPathParam1Arg := myPathParam1Raw
+	myPathParam1Arg := StringAlias(myPathParam1Raw)
 
 	myPathParam2Raw, err := flags.GetString("myPathParam2")
 	if err != nil {

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -1445,12 +1445,13 @@ func (c TestServiceCLICommand) testService_PostSafeParams_CmdRun(cmd *cobra.Comm
 	if err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to parse argument myHeaderParam2")
 	}
-	var myHeaderParam2Arg *uuid.UUID
+	var myHeaderParam2Arg *SafeUuid
 	if myHeaderParam2ArgStr := myHeaderParam2Raw; myHeaderParam2ArgStr != "" {
-		myHeaderParam2ArgInternal, err := uuid.ParseUUID(myHeaderParam2ArgStr)
+		myHeaderParam2ArgInternalValue1, err := uuid.ParseUUID(myHeaderParam2ArgStr)
 		if err != nil {
 			return werror.WrapWithContextParams(ctx, errors.WrapWithInvalidArgument(err), "failed to parse \"myHeaderParam2\" as uuid")
 		}
+		myHeaderParam2ArgInternal := SafeUuid(myHeaderParam2ArgInternalValue1)
 		myHeaderParam2Arg = &myHeaderParam2ArgInternal
 	}
 

--- a/integration_test/testgenerated/server/api/cli.conjure.go
+++ b/integration_test/testgenerated/server/api/cli.conjure.go
@@ -1337,7 +1337,7 @@ func (c TestServiceCLICommand) testService_PostSafeParams_CmdRun(cmd *cobra.Comm
 	if myPathParam1Raw == "" {
 		return werror.ErrorWithContextParams(ctx, "myPathParam1 is a required argument")
 	}
-	myPathParam1Arg := StringAlias(myPathParam1Raw)
+	myPathParam1Arg := myPathParam1Raw
 
 	myPathParam2Raw, err := flags.GetString("myPathParam2")
 	if err != nil {

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -44,7 +44,7 @@ type TestService interface {
 	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
@@ -127,7 +127,7 @@ func RegisterRoutesTestService(router wrouter.Router, impl TestService, routerPa
 	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.SafeQueryParams("myQueryParam6"))...); err != nil {
 		return werror.Wrap(err, "failed to add postPathParam route")
 	}
-	if err := resource.Post("PostSafeParams", "/safe/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostSafeParams, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.ForbiddenPathParams("myPathParam1"), wrouter.SafeHeaderParams("X-My-Header1-Abc"), wrouter.ForbiddenHeaderParams("X-My-Header2"), wrouter.SafeQueryParams("query1"), wrouter.SafeQueryParams("myQueryParam2"), wrouter.ForbiddenQueryParams("myQueryParam4"))...); err != nil {
+	if err := resource.Post("PostSafeParams", "/safe/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostSafeParams, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.SafePathParams("myPathParam1"), wrouter.SafeHeaderParams("X-My-Header1-Abc"), wrouter.ForbiddenHeaderParams("X-My-Header2"), wrouter.SafeQueryParams("query1"), wrouter.SafeQueryParams("myQueryParam2"), wrouter.ForbiddenQueryParams("myQueryParam4"))...); err != nil {
 		return werror.Wrap(err, "failed to add postSafeParams route")
 	}
 	if err := resource.Get("Bytes", "/bytes", httpserver.NewJSONHandler(handler.HandleBytes, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
@@ -622,11 +622,10 @@ func (t *testServiceHandler) HandlePostSafeParams(rw http.ResponseWriter, req *h
 	if pathParams == nil {
 		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
-	myPathParam1ArgStr, ok := pathParams["myPathParam1"]
+	myPathParam1Arg, ok := pathParams["myPathParam1"]
 	if !ok {
 		return werror.WrapWithContextParams(req.Context(), errors.NewInvalidArgument(), "path parameter \"myPathParam1\" not present")
 	}
-	myPathParam1Arg := StringAlias(myPathParam1ArgStr)
 	myPathParam2ArgStr, ok := pathParams["myPathParam2"]
 	if !ok {
 		return werror.WrapWithContextParams(req.Context(), errors.NewInvalidArgument(), "path parameter \"myPathParam2\" not present")

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -44,7 +44,7 @@ type TestService interface {
 	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg io.ReadCloser) (io.ReadCloser, error)
@@ -79,7 +79,7 @@ func RegisterRoutesTestService(router wrouter.Router, impl TestService, routerPa
 	if err := resource.Get("GetPathParam", "/path/string/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
 		return werror.Wrap(err, "failed to add getPathParam route")
 	}
-	if err := resource.Get("GetPathParamAlias", "/path/alias/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParamAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
+	if err := resource.Get("GetPathParamAlias", "/path/alias/{myPathParam}", httpserver.NewJSONHandler(handler.HandleGetPathParamAlias, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.ForbiddenPathParams("myPathParam"))...); err != nil {
 		return werror.Wrap(err, "failed to add getPathParamAlias route")
 	}
 	if err := resource.Get("QueryParamList", "/pathNew", httpserver.NewJSONHandler(handler.HandleQueryParamList, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
@@ -124,10 +124,10 @@ func RegisterRoutesTestService(router wrouter.Router, impl TestService, routerPa
 	if err := resource.Post("PathParamExternalInteger", "/externalIntegerPath/{myPathParam1}", httpserver.NewJSONHandler(handler.HandlePathParamExternalInteger, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
 		return werror.Wrap(err, "failed to add pathParamExternalInteger route")
 	}
-	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
+	if err := resource.Post("PostPathParam", "/path/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostPathParam, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.SafeQueryParams("myQueryParam6"))...); err != nil {
 		return werror.Wrap(err, "failed to add postPathParam route")
 	}
-	if err := resource.Post("PostSafeParams", "/safe/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostSafeParams, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.SafePathParams("myPathParam1"), wrouter.SafeHeaderParams("X-My-Header1-Abc"), wrouter.SafeQueryParams("query1"), wrouter.SafeQueryParams("myQueryParam2"), wrouter.ForbiddenQueryParams("myQueryParam4"))...); err != nil {
+	if err := resource.Post("PostSafeParams", "/safe/{myPathParam1}/{myPathParam2}", httpserver.NewJSONHandler(handler.HandlePostSafeParams, httpserver.StatusCodeMapper, httpserver.ErrHandler), append(routerParams, wrouter.ForbiddenPathParams("myPathParam1"), wrouter.SafeHeaderParams("X-My-Header1-Abc"), wrouter.ForbiddenHeaderParams("X-My-Header2"), wrouter.SafeQueryParams("query1"), wrouter.SafeQueryParams("myQueryParam2"), wrouter.ForbiddenQueryParams("myQueryParam4"))...); err != nil {
 		return werror.Wrap(err, "failed to add postSafeParams route")
 	}
 	if err := resource.Get("Bytes", "/bytes", httpserver.NewJSONHandler(handler.HandleBytes, httpserver.StatusCodeMapper, httpserver.ErrHandler), routerParams...); err != nil {
@@ -622,10 +622,11 @@ func (t *testServiceHandler) HandlePostSafeParams(rw http.ResponseWriter, req *h
 	if pathParams == nil {
 		return werror.Wrap(errors.NewInternal(), "path params not found on request: ensure this endpoint is registered with wrouter")
 	}
-	myPathParam1Arg, ok := pathParams["myPathParam1"]
+	myPathParam1ArgStr, ok := pathParams["myPathParam1"]
 	if !ok {
 		return werror.WrapWithContextParams(req.Context(), errors.NewInvalidArgument(), "path parameter \"myPathParam1\" not present")
 	}
+	myPathParam1Arg := StringAlias(myPathParam1ArgStr)
 	myPathParam2ArgStr, ok := pathParams["myPathParam2"]
 	if !ok {
 		return werror.WrapWithContextParams(req.Context(), errors.NewInvalidArgument(), "path parameter \"myPathParam2\" not present")

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -41,7 +41,7 @@ type TestServiceClient interface {
 	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -428,7 +428,7 @@ func (c *testServiceClient) PostPathParam(ctx context.Context, authHeader bearer
 	return *returnVal, nil
 }
 
-func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PostSafeParams"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
@@ -571,7 +571,7 @@ type TestServiceClientWithAuth interface {
 	PathParamExternalString(ctx context.Context, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -679,7 +679,7 @@ func (c *testServiceClientWithAuth) PostPathParam(ctx context.Context, myPathPar
 	return c.client.PostPathParam(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myQueryParam6Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 
-func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
 	return c.client.PostSafeParams(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -41,7 +41,7 @@ type TestServiceClient interface {
 	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *SafeUuid) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -428,7 +428,7 @@ func (c *testServiceClient) PostPathParam(ctx context.Context, authHeader bearer
 	return *returnVal, nil
 }
 
-func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *SafeUuid) error {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PostSafeParams"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
@@ -571,7 +571,7 @@ type TestServiceClientWithAuth interface {
 	PathParamExternalString(ctx context.Context, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *SafeUuid) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -679,7 +679,7 @@ func (c *testServiceClientWithAuth) PostPathParam(ctx context.Context, myPathPar
 	return c.client.PostPathParam(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myQueryParam6Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 
-func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *SafeUuid) error {
 	return c.client.PostSafeParams(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 

--- a/integration_test/testgenerated/server/api/services.conjure.go
+++ b/integration_test/testgenerated/server/api/services.conjure.go
@@ -41,7 +41,7 @@ type TestServiceClient interface {
 	PathParamExternalString(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -428,7 +428,7 @@ func (c *testServiceClient) PostPathParam(ctx context.Context, authHeader bearer
 	return *returnVal, nil
 }
 
-func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClient) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PostSafeParams"))
 	requestParams = append(requestParams, httpclient.WithRequestMethod("POST"))
@@ -571,7 +571,7 @@ type TestServiceClientWithAuth interface {
 	PathParamExternalString(ctx context.Context, myPathParam1Arg string) error
 	PathParamExternalInteger(ctx context.Context, myPathParam1Arg int) error
 	PostPathParam(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myQueryParam6Arg OptionalIntegerAlias, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) (CustomObject, error)
-	PostSafeParams(ctx context.Context, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
+	PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error
 	Bytes(ctx context.Context) (CustomObject, error)
 	GetBinary(ctx context.Context) (io.ReadCloser, error)
 	PostBinary(ctx context.Context, myBytesArg func() io.ReadCloser) (io.ReadCloser, error)
@@ -679,7 +679,7 @@ func (c *testServiceClientWithAuth) PostPathParam(ctx context.Context, myPathPar
 	return c.client.PostPathParam(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myQueryParam6Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 
-func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg StringAlias, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+func (c *testServiceClientWithAuth) PostSafeParams(ctx context.Context, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg CustomObject, myQueryParam1Arg string, myQueryParam2Arg string, myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
 	return c.client.PostSafeParams(ctx, c.authHeader, myPathParam1Arg, myPathParam2Arg, myBodyParamArg, myQueryParam1Arg, myQueryParam2Arg, myQueryParam3Arg, myQueryParam4Arg, myQueryParam5Arg, myHeaderParam1Arg, myHeaderParam2Arg)
 }
 

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -1,5 +1,8 @@
 types:
   imports:
+    DoNotLog:
+      external:
+        java: com.palantir.logsafe.DoNotLog
     Safe:
       external:
         java: com.palantir.logsafe.Safe
@@ -19,8 +22,10 @@ types:
     objects:
       StringAlias:
         alias: string
+        safety: do-not-log
       OptionalIntegerAlias:
         alias: optional<integer>
+        safety: safe
       OptionalListAlias:
         alias: optional<list<string>>
       CustomObject:
@@ -202,10 +207,7 @@ services:
         http: POST /safe/{myPathParam1}/{myPathParam2}
         auth: header
         args:
-          myPathParam1:
-            type: string
-            markers:
-              - Safe
+          myPathParam1: StringAlias
           myPathParam2: boolean
           myBodyParam:
             type: CustomObject
@@ -242,6 +244,7 @@ services:
             type: optional<uuid>
             param-type: header
             param-id: X-My-Header2
+            safety: do-not-log
       bytes:
         http: GET /bytes
         returns: CustomObject

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -31,6 +31,9 @@ types:
       CustomObject:
         fields:
           data: binary
+      SafeUuid:
+        alias: uuid
+        safety: safe
 services:
   TestService:
     name: Test Service
@@ -244,10 +247,9 @@ services:
             markers:
               - Safe
           myHeaderParam2:
-            type: optional<uuid>
+            type: optional<SafeUuid>
             param-type: header
             param-id: X-My-Header2
-            safety: do-not-log
       bytes:
         http: GET /bytes
         returns: CustomObject

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -207,7 +207,10 @@ services:
         http: POST /safe/{myPathParam1}/{myPathParam2}
         auth: header
         args:
-          myPathParam1: StringAlias
+          myPathParam1:
+            type: string
+            markers:
+              - Safe
           myPathParam2: boolean
           myBodyParam:
             type: CustomObject

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -68,12 +68,13 @@ func TestSafeMarker(t *testing.T) {
 
 			headerPerms := reqVals.ParamPerms.HeaderParamPerms()
 			assert.True(t, headerPerms.Safe("X-My-Header1-Abc"))
-			assert.False(t, headerPerms.Safe("X-My-Header2"))
+			assert.True(t, headerPerms.Safe("X-My-Header2"))
 
 			queryPerms := reqVals.ParamPerms.QueryParamPerms()
 			assert.True(t, queryPerms.Safe("query1"))
 			assert.True(t, queryPerms.Safe("myQueryParam2"))
 			assert.False(t, queryPerms.Safe("myQueryParam3"))
+			assert.True(t, queryPerms.Forbidden("myQueryParam4"))
 		}
 		next(rw, r, reqVals)
 	})

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -96,7 +96,7 @@ func TestSafeMarker(t *testing.T) {
 		&long2,
 		&str,
 		2,
-		&id)
+		(*api.SafeUuid)(&id))
 	require.NoError(t, err)
 	assert.True(t, called)
 }
@@ -262,7 +262,7 @@ func TestEchoQueryParamSet(t *testing.T) {
 type testServerImpl struct{}
 
 func (t testServerImpl) PostSafeParams(ctx context.Context, authHeader bearertoken.Token, myPathParam1Arg string, myPathParam2Arg bool, myBodyParamArg api.CustomObject, myQueryParam1Arg string, myQueryParam2Arg string,
-	myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *uuid.UUID) error {
+	myQueryParam3Arg float64, myQueryParam4Arg *safelong.SafeLong, myQueryParam5Arg *string, myHeaderParam1Arg safelong.SafeLong, myHeaderParam2Arg *api.SafeUuid) error {
 	switch {
 	case authHeader == "":
 		return errors.New("empty authHeader")


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/403)
<!-- Reviewable:end -->
