### PR TITLE
render conjure deprecation warnings in generated code

### DIFF
--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    - Conjure-go will unmarshal EnumValues marked as deprecated without throwing, in accordance with the [spec](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#enumvaluedefinition)
+     - Deprecation warnings will be rendered if defined on endpoints, enum values, and fields
+     - The repo will build on arm macbooks
+  links:
+  - https://github.com/palantir/conjure-go/pull/432

--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -28,7 +28,7 @@ const (
 )
 
 func writeEnumType(file *jen.Group, enumDef *types.EnumType) {
-	file.Add(enumDef.CommentLine()).Add(astForEnumTypeDecls(enumDef.Name))
+	file.Add(enumDef.CommentLineWithDeprecation(enumDef.Deprecated)).Add(astForEnumTypeDecls(enumDef.Name))
 	file.Add(astForEnumValueConstants(enumDef.Name, enumDef.Values))
 	file.Add(astForEnumValuesFunction(enumDef.Name, enumDef.Values))
 	file.Add(astForEnumConstructor(enumDef.Name))
@@ -48,7 +48,7 @@ func astForEnumTypeDecls(typeName string) *jen.Statement {
 func astForEnumValueConstants(typeName string, values []*types.Field) *jen.Statement {
 	return jen.Const().DefsFunc(func(consts *jen.Group) {
 		for _, valDef := range values {
-			consts.Add(valDef.CommentLine()).
+			consts.Add(valDef.CommentLineWithDeprecation(valDef.Deprecated)).
 				Id(typeName + "_" + valDef.Name).Id(typeName + "_Value").Op("=").Lit(valDef.Name)
 		}
 		consts.Id(typeName + "_" + enumUnknownValue).Id(typeName + "_Value").Op("=").Lit(enumUnknownValue)

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -45,7 +45,7 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 			if fieldDef.Type.Make() != nil {
 				containsCollection = true
 			}
-			structDecl.Add(fieldDef.Docs.CommentLine()).Id(transforms.ExportedFieldName(fieldName)).Add(fieldDef.Type.Code()).Tag(fieldTags)
+			structDecl.Add(fieldDef.Docs.CommentLineWithDeprecation(fieldDef.Deprecated)).Id(transforms.ExportedFieldName(fieldName)).Add(fieldDef.Type.Code()).Tag(fieldTags)
 		}
 	})
 

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -88,7 +88,8 @@ func astForServiceInterface(serviceDef *types.ServiceDefinition, withAuth, isSer
 		Id(name).
 		InterfaceFunc(func(methods *jen.Group) {
 			for _, endpointDef := range serviceDef.Endpoints {
-				methods.Add(endpointDef.Docs.CommentLine()).Id(transforms.Export(endpointDef.EndpointName)).
+				methods.Add(endpointDef.CommentLineWithDeprecation(endpointDef.Deprecated)).
+					Id(transforms.Export(endpointDef.EndpointName)).
 					ParamsFunc(func(args *jen.Group) {
 						astForEndpointArgsFunc(args, endpointDef, withAuth, isServer)
 					}).

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -390,16 +390,18 @@ func newFields(names *namedTypes, structDefs []spec.FieldDefinition, enumDefs []
 			logSafetyWarning()
 		}
 		fields = append(fields, &Field{
-			Docs: Docs(transforms.Documentation(value.Docs)),
-			Name: string(value.FieldName),
-			Type: names.GetBySpec(value.Type),
+			Docs:       Docs(transforms.Documentation(value.Docs)),
+			Deprecated: Docs(transforms.Documentation(value.Deprecated)),
+			Name:       string(value.FieldName),
+			Type:       names.GetBySpec(value.Type),
 		})
 	}
 	for _, value := range enumDefs {
 		fields = append(fields, &Field{
-			Docs: Docs(transforms.Documentation(value.Docs)),
-			Name: value.Value,
-			Type: String{},
+			Docs:       Docs(transforms.Documentation(value.Docs)),
+			Deprecated: Docs(transforms.Documentation(value.Deprecated)),
+			Name:       value.Value,
+			Type:       String{},
 		})
 	}
 	return fields

--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -253,6 +253,7 @@ func (t *AliasType) Safety() spec.LogSafety {
 
 type EnumType struct {
 	Docs
+	Deprecated Docs
 	Name       string
 	Values     []*Field
 	conjurePkg string
@@ -343,6 +344,16 @@ func (c Docs) CommentLine() *jen.Statement {
 		return jen.Comment(string(c)).Line()
 	}
 	return jen.Empty()
+}
+
+func (c Docs) CommentLineWithDeprecation(deprecated Docs) *jen.Statement {
+	if deprecated == "" {
+		return c.CommentLine()
+	}
+	if c == "" {
+		return jen.Commentf("Deprecated: %s", deprecated).Line()
+	}
+	return jen.Commentf("%s\n\nDeprecated: %s", c, deprecated).Line()
 }
 
 type EnumValue struct {

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -7,6 +7,8 @@ products:
       os-archs:
       - os: darwin
         arch: amd64
+      - os: darwin
+        arch: arm64
       - os: linux
         arch: amd64
     dist:
@@ -17,6 +19,8 @@ products:
             os-archs:
             - os: darwin
               arch: amd64
+            - os: darwin
+              arch: arm64
             - os: linux
               arch: amd64
     publish: {}

--- a/integration_test/testgenerated/objects/api/enums.conjure.go
+++ b/integration_test/testgenerated/objects/api/enums.conjure.go
@@ -110,6 +110,7 @@ func (e *EmptyValuesEnum) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// this is an enum
 type Enum struct {
 	val Enum_Value
 }
@@ -122,7 +123,11 @@ const (
 	Enum_VALUES_1   Enum_Value = "VALUES_1"
 	Enum_VALUES_1_1 Enum_Value = "VALUES_1_1"
 	Enum_VALUE1     Enum_Value = "VALUE1"
-	// Docs for an enum value
+	/*
+	   Docs for an enum value
+
+	   Deprecated: Do not use this value
+	*/
 	Enum_VALUE2  Enum_Value = "VALUE2"
 	Enum_UNKNOWN Enum_Value = "UNKNOWN"
 )

--- a/integration_test/testgenerated/objects/api/structs.conjure.go
+++ b/integration_test/testgenerated/objects/api/structs.conjure.go
@@ -137,7 +137,12 @@ func (o *BooleanIntegerMap) UnmarshalYAML(unmarshal func(interface{}) error) err
 }
 
 type Collections struct {
-	MapVar   map[string][]int   `json:"mapVar"`
+	/*
+	   field docs
+
+	   Deprecated: do not use this field
+	*/
+	MapVar   map[string][]int   `conjure-docs:"field docs" json:"mapVar"`
 	ListVar  []string           `json:"listVar"`
 	MultiDim [][]map[string]int `json:"multiDim"`
 }

--- a/integration_test/testgenerated/objects/objects.yml
+++ b/integration_test/testgenerated/objects/objects.yml
@@ -19,7 +19,10 @@ types:
               newline and "quotes".
       Collections:
         fields:
-          mapVar: map<string, list<integer>>
+          mapVar:
+            type: map<string, list<integer>>
+            docs: "field docs"
+            deprecated: "do not use this field"
           listVar: list<string>
           multiDim: list<list<map<string, integer>>>
       Compound:
@@ -57,6 +60,7 @@ types:
           type: list<string>
           chan: map<string, string>
       Enum:
+        docs: "this is an enum"
         values:
           - VALUE
           - VALUES
@@ -65,6 +69,7 @@ types:
           - VALUE1
           - value: VALUE2
             docs: Docs for an enum value
+            deprecated: Do not use this value
       EmptyValuesEnum:
         values: [ ]
       Days:

--- a/integration_test/testgenerated/post/api/cli.conjure.go
+++ b/integration_test/testgenerated/post/api/cli.conjure.go
@@ -70,7 +70,7 @@ func NewTestServiceCLICommandWithClientProvider(clientProvider CLITestServiceCli
 
 	testService_Echo_Cmd := &cobra.Command{
 		RunE:  cliCommand.testService_Echo_CmdRun,
-		Short: "Calls the echo endpoint.",
+		Short: "Some echo docs here\nwith newlines",
 		Use:   "echo",
 	}
 	rootCmd.AddCommand(testService_Echo_Cmd)

--- a/integration_test/testgenerated/post/api/servers.conjure.go
+++ b/integration_test/testgenerated/post/api/servers.conjure.go
@@ -15,6 +15,15 @@ import (
 )
 
 type TestService interface {
+	/*
+	   Some echo docs here
+	   with newlines
+
+	   Deprecated: Use something
+	   else
+	   with
+	   newlines
+	*/
 	Echo(ctx context.Context, inputArg string) (string, error)
 }
 

--- a/integration_test/testgenerated/post/api/services.conjure.go
+++ b/integration_test/testgenerated/post/api/services.conjure.go
@@ -10,6 +10,15 @@ import (
 )
 
 type TestServiceClient interface {
+	/*
+	   Some echo docs here
+	   with newlines
+
+	   Deprecated: Use something
+	   else
+	   with
+	   newlines
+	*/
 	Echo(ctx context.Context, inputArg string) (string, error)
 }
 

--- a/integration_test/testgenerated/post/post-service.yml
+++ b/integration_test/testgenerated/post/post-service.yml
@@ -4,6 +4,14 @@ services:
     package: api
     endpoints:
       echo:
+        docs: |
+          Some echo docs here
+          with newlines
+        deprecated: |
+          Use something
+          else
+          with
+          newlines
         http: POST /echo
         args:
           input:


### PR DESCRIPTION
## Before this PR
Conjure allows marking endpoints, fields, and enum values as deprecated, with a message indicating what users should migrate to. Conjure-go does not render these deprecation notices in generated client code, making it more difficult to notice when you are using deprecated endpoints or to easily understand what you should use instead.

## After this PR

==COMMIT_MSG==
 - Conjure-go will unmarshal EnumValues marked as deprecated without throwing, in accordance with the [spec](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#enumvaluedefinition)
 - Deprecation warnings will be rendered if defined on endpoints, enum values, and fields
 - The repo will build on arm macbooks
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/432)
<!-- Reviewable:end -->

This should be a docs-only change to existing generated code, making this low risk.
