### PR TITLE
Improvement: Correctly handle 'internal' as part of conjure package names

### DIFF
--- a/changelog/@unreleased/pr-433.v2.yml
+++ b/changelog/@unreleased/pr-433.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Correctly handle 'internal' as part of conjure package names
+  links:
+  - https://github.com/palantir/conjure-go/pull/433

--- a/conjure/transforms/transforms.go
+++ b/conjure/transforms/transforms.go
@@ -88,6 +88,12 @@ func PackagePath(conjurePkgName string) string {
 		// if package has more than 3 parts, trim first two (typically "com.palantir")
 		parts = parts[2:]
 	}
+	for i, part := range parts {
+		// Handle package names including the word "internal" to avoid making them internal
+		if part == "internal" {
+			parts[i] = "internal_"
+		}
+	}
 	return path.Join(parts...)
 }
 

--- a/conjure/transforms/transforms_test.go
+++ b/conjure/transforms/transforms_test.go
@@ -33,3 +33,8 @@ func TestFieldNames(t *testing.T) {
 	assert.Equal(t, "SnakeTest", transforms.ExportedFieldName("snake_test_"))
 	assert.Equal(t, "SnakeTestTest", transforms.ExportedFieldName("snake___test__test"))
 }
+
+func TestPackageNames(t *testing.T) {
+	assert.Equal(t, "package/name", transforms.PackagePath("com.company.package.name"))
+	assert.Equal(t, "internal_/name", transforms.PackagePath("com.company.internal.name"))
+}


### PR DESCRIPTION


## Before this PR
Using a package name like `com.company.package.internal` would lead to an `internal` package being created, making it inaccessible.

## After this PR
`internal` is correctly translated to `internal_`, ensuring no unexpected side effects when rendering for golang.

==COMMIT_MSG==
Correctly handle 'internal' as part of conjure package names
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/433)
<!-- Reviewable:end -->
