### PR TITLE
fix: Apply type transform to ErrorName and ServiceName

### DIFF
--- a/changelog/@unreleased/pr-483.v2.yml
+++ b/changelog/@unreleased/pr-483.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Apply type transform to ErrorName and ServiceName
+  links:
+  - https://github.com/palantir/conjure-go/pull/483

--- a/conjure/cycles/package.go
+++ b/conjure/cycles/package.go
@@ -184,6 +184,11 @@ func mergePackages(packageSet packageSet, numSimilarPackageSet int) (ret string)
 
 func applyTypeTransformToDef(def spec.ConjureDefinition, typeTransform typeTransformFn) (spec.ConjureDefinition, error) {
 	for i, errorDef := range def.Errors {
+		newType, err := typeTransform(errorDef.ErrorName)
+		if err != nil {
+			return spec.ConjureDefinition{}, err
+		}
+		def.Errors[i].ErrorName = newType
 		for j, field := range errorDef.SafeArgs {
 			newType, err := applyTypeTransformToType(field.Type, typeTransform)
 			if err != nil {
@@ -265,6 +270,11 @@ func applyTypeTransformToDef(def spec.ConjureDefinition, typeTransform typeTrans
 	}
 
 	for i, serviceDef := range def.Services {
+		newType, err := typeTransform(serviceDef.ServiceName)
+		if err != nil {
+			return spec.ConjureDefinition{}, err
+		}
+		def.Services[i].ServiceName = newType
 		for j, endpointDef := range serviceDef.Endpoints {
 			if endpointDef.Returns != nil {
 				newType, err := applyTypeTransformToType(*endpointDef.Returns, typeTransform)


### PR DESCRIPTION
## Summary
These flew under the radar.

## Changelog
==COMMIT_MSG==
Apply type transform to ErrorName and ServiceName
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/483)
<!-- Reviewable:end -->
