### PR TITLE
Fix: Update conjure-verifier URLs

### DIFF
--- a/changelog/@unreleased/pr-494.v2.yml
+++ b/changelog/@unreleased/pr-494.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Update conjure-verifier URLs to use the Sonatype maven repo now that
+    Bintray is deprecated
+  links:
+  - https://github.com/palantir/conjure-go/pull/494

--- a/conjure-go-verifier/generate/generate.go
+++ b/conjure-go-verifier/generate/generate.go
@@ -56,10 +56,10 @@ const verificationServerVersion = "%s"
 
 	// if version file exists and is in desired state, assume that all downloaded content is in desired state
 	if currVersionFileContent, err := ioutil.ReadFile(versionFilePath); err != nil || string(currVersionFileContent) != newVersionFileContent {
-		if err := downloadFile(clientTestCasesFile, fmt.Sprintf("https://palantir.bintray.com/releases/com/palantir/conjure/verification/verification-server-test-cases/%s/verification-server-test-cases-%s.json", conjureVerifierVersion, conjureVerifierVersion)); err != nil {
+		if err := downloadFile(clientTestCasesFile, fmt.Sprintf("https://repo1.maven.org/maven2/com/palantir/conjure/verification/verification-server-test-cases/%s/verification-server-test-cases-%s.json", conjureVerifierVersion, conjureVerifierVersion)); err != nil {
 			panic(err)
 		}
-		if err := downloadFile(clientVerificationAPIFile, fmt.Sprintf("https://palantir.bintray.com/releases/com/palantir/conjure/verification/verification-server-api/%s/verification-server-api-%s.conjure.json", conjureVerifierVersion, conjureVerifierVersion)); err != nil {
+		if err := downloadFile(clientVerificationAPIFile, fmt.Sprintf("https://repo1.maven.org/maven2/com/palantir/conjure/verification/verification-server-api/%s/verification-server-api-%s.conjure.json", conjureVerifierVersion, conjureVerifierVersion)); err != nil {
 			panic(err)
 		}
 		// update version in circle.yml


### PR DESCRIPTION
## Before this PR
Bintray has been deprecated for a couple years and the conjure-verifier project has moved to publishing to a Sonatype maven repo instead (https://github.com/palantir/conjure-verification/pull/477).

The generate task was already broken but we didn't notice because the versioned files are already up to date. If you tweak the [version_test.go](https://github.com/palantir/conjure-go/blob/develop/conjure-go-verifier/version_test.go) file and run `./godelw generate` you can repro the failure to download the files.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update conjure-verifier URLs to use the Sonatype maven repo now that Bintray is deprecated
==COMMIT_MSG==

I verified this change works locally by updating the [version_test.go](https://github.com/palantir/conjure-go/blob/develop/conjure-go-verifier/version_test.go) and re-running `./godelw generate` which now succeeds with the Sonatype repo.

Other `conjure-xx-runtime` libraries use the same URLs:
- conjure-rust-runtime: https://github.com/palantir/conjure-rust-runtime/blob/develop/conjure-verification-api/build.rs#L32
- conjure-typescript-runtime: https://github.com/palantir/conjure-typescript-runtime/blob/develop/packages/conjure-client/scripts/download-test-server.sh#L34



## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/494)
<!-- Reviewable:end -->
