### PR TITLE
Fix issue with cycle detection and 

### DIFF
--- a/changelog/@unreleased/pr-565.v2.yml
+++ b/changelog/@unreleased/pr-565.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Handle case in cycle detection where a node's previously merged nodes
+    were not checked when evaluating whether it could merge with another node
+  links:
+  - https://github.com/palantir/conjure-go/pull/565

--- a/conjure/cycles/bitset.go
+++ b/conjure/cycles/bitset.go
@@ -72,3 +72,12 @@ func (bs bitset) merge(o bitset) bitset {
 	}
 	return ret
 }
+
+func (bs bitset) intersects(other bitset) bool {
+	for i := range bs.bits {
+		if bs.bits[i]&other.bits[i] != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/conjure/cycles/partition.go
+++ b/conjure/cycles/partition.go
@@ -115,7 +115,6 @@ func (p *partitioner[T, V]) dfs(u *node[T], visited map[T]struct{}) {
 }
 
 func (p *partitioner[T, V]) processDependency(uID, vID T) {
-	// fmt.Printf("Processing dependency %v -> %v\n", uID, vID)
 	p.dependencies[uID] = p.dependencies[uID].merge(p.dependencies[vID])
 
 	// If the node v (dependency of u) can't merge with node w (dependency of v),

--- a/conjure/cycles/partition.go
+++ b/conjure/cycles/partition.go
@@ -32,6 +32,7 @@ type partitioner[T, V comparable] struct {
 	idToBit      map[T]bitID
 	disallowed   map[T]bitset // For each node, the nodes that, if merged, would cause a cycle.
 	dependencies map[T]bitset // For each node u, the nodes that can be reached by u. Contains u.
+	group        map[T]bitset // For each node u, the nodes that are in the same grouping as u. Contains u.
 	revToposort  []T
 
 	// used for sorting edges to keep algorithm stable.
@@ -59,6 +60,7 @@ func (p *partitioner[T, V]) run() map[V][][]T {
 	visited := make(map[T]struct{}, p.numNodes)
 	p.disallowed = make(map[T]bitset, p.numNodes)
 	p.dependencies = make(map[T]bitset, p.numNodes)
+	p.group = make(map[T]bitset, p.numNodes)
 	p.revToposort = make([]T, 0, p.numNodes)
 	for _, u := range p.g.nodes {
 		p.dfs(u, visited)
@@ -100,6 +102,9 @@ func (p *partitioner[T, V]) dfs(u *node[T], visited map[T]struct{}) {
 	dependencies := newBitset(p.numNodes)
 	dependencies.add(p.idToBit[u.id])
 	p.dependencies[u.id] = dependencies
+	group := newBitset(p.numNodes)
+	group.add(p.idToBit[u.id])
+	p.group[u.id] = group
 
 	for _, v := range u.sortedEdges(p.comparator) {
 		p.dfs(v, visited)
@@ -110,6 +115,7 @@ func (p *partitioner[T, V]) dfs(u *node[T], visited map[T]struct{}) {
 }
 
 func (p *partitioner[T, V]) processDependency(uID, vID T) {
+	// fmt.Printf("Processing dependency %v -> %v\n", uID, vID)
 	p.dependencies[uID] = p.dependencies[uID].merge(p.dependencies[vID])
 
 	// If the node v (dependency of u) can't merge with node w (dependency of v),
@@ -132,8 +138,7 @@ func (p *partitioner[T, V]) canMerge(id1, id2 T) bool {
 		return false
 	}
 	// Check if one is a disallowed dependency of the other.
-	return !p.disallowed[id1].has(p.idToBit[id2]) &&
-		!p.disallowed[id2].has(p.idToBit[id1])
+	return !p.disallowed[id1].intersects(p.group[id2]) && !p.disallowed[id2].intersects(p.group[id1])
 }
 
 func (p *partitioner[T, V]) merge(id1, id2 T) {
@@ -143,6 +148,8 @@ func (p *partitioner[T, V]) merge(id1, id2 T) {
 	v.addEdge(u)
 	p.revDfs(u, v, make(map[T]struct{}))
 	p.revDfs(v, u, make(map[T]struct{}))
+	p.group[u.id] = p.group[u.id].merge(p.group[v.id])
+	p.group[v.id] = p.group[u.id]
 }
 
 func (p *partitioner[T, V]) revDfs(u *node[T], newDep *node[T], visited map[T]struct{}) {

--- a/conjure/cycles/partition_test.go
+++ b/conjure/cycles/partition_test.go
@@ -144,6 +144,31 @@ func TestPartition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nodes of the same color can't be merged due to intersecting groupings",
+			graph: newGraph[int](4).
+				addNode(0).
+				addNode(1).
+				addNode(2).
+				addNode(3).
+				addEdgesByID(2, 1).
+				addEdgesByID(3, 2),
+			colorByID: map[int]string{
+				0: "red",
+				1: "red",
+				2: "green",
+				3: "red",
+			},
+			expected: map[string][][]int{
+				"red": {
+					{0, 1},
+					{3},
+				},
+				"green": {
+					{2},
+				},
+			},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := partition(testCase.graph, testCase.colorByID)

--- a/conjure/types/conjure_definition_test.go
+++ b/conjure/types/conjure_definition_test.go
@@ -285,31 +285,6 @@ func TestNewConjureDefinition(t *testing.T) {
 								importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
 							},
 							{
-								Name: "ObjectAlias",
-								Item: &ObjectType{
-									Name: "TestType",
-									Fields: []*Field{
-										{
-											Name: "alias",
-											Type: &AliasType{
-												Name:       "ExampleAlias",
-												Item:       String{},
-												conjurePkg: "com.palantir.test.api",
-												importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
-											},
-										},
-										{Name: "rid", Type: RID{}},
-										{Name: "large_int", Type: Safelong{}},
-										{Name: "time", Type: DateTime{}},
-										{Name: "bytes", Type: Binary{}},
-									},
-									conjurePkg: "com.palantir.foundry.catalog.api.datasets",
-									importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/foundry/catalog/api/datasets",
-								},
-								conjurePkg: "com.palantir.test.api",
-								importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
-							},
-							{
 								Name: "AliasAlias",
 								Item: &AliasType{
 									Name:       "Status",
@@ -333,6 +308,39 @@ func TestNewConjureDefinition(t *testing.T) {
 								Values:     []*Field{{Name: "FRIDAY", Type: String{}}, {Name: "SATURDAY", Type: String{}}},
 								conjurePkg: "com.palantir.test.api",
 								importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
+							},
+						},
+					},
+					"com.palantir.test.api1": {
+						ConjurePackage: "com.palantir.test.api1",
+						ImportPath:     "github.com/palantir/conjure-go/v6/conjure/types/test/test/api1",
+						OutputDir:      "test/test/api1",
+						PackageName:    "api1",
+						Aliases: []*AliasType{
+							{
+								Name: "ObjectAlias",
+								Item: &ObjectType{
+									Name: "TestType",
+									Fields: []*Field{
+										{
+											Name: "alias",
+											Type: &AliasType{
+												Name:       "ExampleAlias",
+												Item:       String{},
+												conjurePkg: "com.palantir.test.api",
+												importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
+											},
+										},
+										{Name: "rid", Type: RID{}},
+										{Name: "large_int", Type: Safelong{}},
+										{Name: "time", Type: DateTime{}},
+										{Name: "bytes", Type: Binary{}},
+									},
+									conjurePkg: "com.palantir.foundry.catalog.api.datasets",
+									importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/foundry/catalog/api/datasets",
+								},
+								conjurePkg: "com.palantir.test.api1",
+								importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api1",
 							},
 						},
 						Unions: []*UnionType{
@@ -378,8 +386,8 @@ func TestNewConjureDefinition(t *testing.T) {
 											},
 										},
 									},
-									conjurePkg: "com.palantir.test.api",
-									importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api",
+									conjurePkg: "com.palantir.test.api1",
+									importPath: "github.com/palantir/conjure-go/v6/conjure/types/test/test/api1",
 								}
 								u.Fields = append(u.Fields, &Field{
 									Name: "recursive",


### PR DESCRIPTION
## Before this PR
The cycle detection algorithm did not check for disallowed nodes in the same merged group as the target node. 

### Example:
Nodes: 0, 1, 2, and 3

Colors:
* 0 - Red
* 1 - Red
* 2 - Blue
* 3 - Red

Edges:
* 2 -> 1
* 3 -> 2

### Initial disallowed state
```
0: []
1: []
2: [1]
3: [2, 1]
```
### Partitioning
1. 0 and 1 attempt to merge
1. 0 and 1 are the same color and are not on each others' disallow lists so they merge
1. 3 and 0 attempt to merge
1. 3 and 0 are the same color and are not on each others' disallow lists so they merge
1. 3 and 1 are now in the same group, causing a cycle

## After this PR

1. The algorithm now keeps track of all of the nodes that have been merged with a given node
1. When evaluating whether two nodes can merge, check whether there is any intersection between each node's disallowed nodes and the other node's merged nodes

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle case in cycle detection where a node's previously merged nodes were not checked when evaluating whether it could merge with another node
==COMMIT_MSG==

## Possible downsides?
* Intersection is more expensive
* We are adding another bitset for every node
* This may cause previously generated conjure bindings to change if there were undetected cycles

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/565)
<!-- Reviewable:end -->
