### PR TITLE
improvement: Remove conjure-docs struct field tag

### DIFF
--- a/changelog/@unreleased/pr-592.v2.yml
+++ b/changelog/@unreleased/pr-592.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove conjure-docs struct field tag
+  links:
+  - https://github.com/palantir/conjure-go/pull/592

--- a/conjure-api/conjure/spec/structs.conjure.go
+++ b/conjure-api/conjure/spec/structs.conjure.go
@@ -365,9 +365,9 @@ func (o *ErrorDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error
 
 type ExternalReference struct {
 	// An identifier for a non-Conjure type which is already defined in a different language (e.g. Java).
-	ExternalReference TypeName `conjure-docs:"An identifier for a non-Conjure type which is already defined in a different language (e.g. Java)." json:"externalReference"`
+	ExternalReference TypeName `json:"externalReference"`
 	// Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
-	Fallback Type `conjure-docs:"Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable." json:"fallback"`
+	Fallback Type `json:"fallback"`
 }
 
 func (o ExternalReference) MarshalYAML() (interface{}, error) {
@@ -655,9 +655,9 @@ func (o *SetType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 type TypeName struct {
 	// The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: "FooBar", "XYCoordinate", "Build2Request". Disallowed names: "fooBar", "2BuildRequest".
-	Name string `conjure-docs:"The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: \"FooBar\", \"XYCoordinate\", \"Build2Request\". Disallowed names: \"fooBar\", \"2BuildRequest\"." json:"name"`
+	Name string `json:"name"`
 	// A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: "foo", "com.palantir.bar", "com.palantir.foo.thing2". Disallowed packages: "Foo", "com.palantir.foo.2thing".
-	Package string `conjure-docs:"A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: \"foo\", \"com.palantir.bar\", \"com.palantir.foo.thing2\". Disallowed packages: \"Foo\", \"com.palantir.foo.2thing\"." json:"package"`
+	Package string `json:"package"`
 }
 
 func (o TypeName) MarshalYAML() (interface{}, error) {

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -15,8 +15,6 @@
 package conjure
 
 import (
-	"strings"
-
 	"github.com/dave/jennifer/jen"
 	"github.com/palantir/conjure-go/v6/conjure/snip"
 	"github.com/palantir/conjure-go/v6/conjure/transforms"
@@ -36,12 +34,6 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 			fieldName := fieldDef.Name
 			fieldTags := map[string]string{"json": fieldName}
 
-			if fieldDef.Docs != "" {
-				// backtick characters ("`") are really painful to deal with in struct tags
-				// (which are themselves defined within backtick literals), so replace with
-				// double quotes instead.
-				fieldTags["conjure-docs"] = strings.Replace(strings.TrimSpace(string(fieldDef.Docs)), "`", `"`, -1)
-			}
 			if fieldDef.Type.Make() != nil {
 				containsCollection = true
 			}

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -16,11 +16,11 @@ import (
 
 type myInternal struct {
 	// This is safeArgA doc.
-	SafeArgA Basic `conjure-docs:"This is safeArgA doc." json:"safeArgA"`
+	SafeArgA Basic `json:"safeArgA"`
 	// This is safeArgB doc.
-	SafeArgB []int `conjure-docs:"This is safeArgB doc." json:"safeArgB"`
+	SafeArgB []int `json:"safeArgB"`
 	// A field named with a go keyword
-	Type       string  `conjure-docs:"A field named with a go keyword" json:"type"`
+	Type       string  `json:"type"`
 	UnsafeArgA string  `json:"unsafeArgA"`
 	UnsafeArgB *string `json:"unsafeArgB"`
 	MyInternal string  `json:"myInternal"`
@@ -195,11 +195,11 @@ func (e *MyInternal) UnmarshalJSON(data []byte) error {
 
 type myNotFound struct {
 	// This is safeArgA doc.
-	SafeArgA Basic `conjure-docs:"This is safeArgA doc." json:"safeArgA"`
+	SafeArgA Basic `json:"safeArgA"`
 	// This is safeArgB doc.
-	SafeArgB []int `conjure-docs:"This is safeArgB doc." json:"safeArgB"`
+	SafeArgB []int `json:"safeArgB"`
 	// A field named with a go keyword
-	Type       string  `conjure-docs:"A field named with a go keyword" json:"type"`
+	Type       string  `json:"type"`
 	UnsafeArgA string  `json:"unsafeArgA"`
 	UnsafeArgB *string `json:"unsafeArgB"`
 }

--- a/integration_test/testgenerated/objects/api/structs.conjure.go
+++ b/integration_test/testgenerated/objects/api/structs.conjure.go
@@ -35,7 +35,7 @@ type Basic struct {
 	   A docs string with
 	   newline and "quotes".
 	*/
-	Data string `conjure-docs:"A docs string with\nnewline and \"quotes\"." json:"data"`
+	Data string `json:"data"`
 }
 
 func (o Basic) MarshalYAML() (interface{}, error) {
@@ -142,7 +142,7 @@ type Collections struct {
 
 	   Deprecated: do not use this field
 	*/
-	MapVar   map[string][]int   `conjure-docs:"field docs" json:"mapVar"`
+	MapVar   map[string][]int   `json:"mapVar"`
 	ListVar  []string           `json:"listVar"`
 	MultiDim [][]map[string]int `json:"multiDim"`
 }


### PR DESCRIPTION
These struct tags are not read, are repeated above, and clutter the API definitions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/592)
<!-- Reviewable:end -->
