### PR TITLE
improvement: Generated errors IsError functions match by name, not go type assertion

### DIFF
--- a/changelog/@unreleased/pr-643.v2.yml
+++ b/changelog/@unreleased/pr-643.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generated errors IsError functions match by name, not go type assertion
+  links:
+  - https://github.com/palantir/conjure-go/pull/643

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -500,19 +500,17 @@ func astErrorInitFunc(file *jen.Group, defs []*types.ErrorDefinition, errorRegis
 // astIsErrorTypeFunc generates a helper func that checks whether an error is of the error type:
 //
 //	func IsMyNotFound(err error) bool {
-//		   if err == nil {
-//			   return false
-//		   }
-//		   _, ok := errors.GetConjureError(err).(*MyNotFound)
-//		   return ok
+//		   cerr := errors.GetConjureError(err)
+//		   return cerr != nil && cerr.Name() == "MyNamespace:MyNotFound"
 //	}
 func astIsErrorTypeFunc(file *jen.Group, def *types.ErrorDefinition) {
 	name := "Is" + def.Name
 	file.Commentf("%s returns true if err is an instance of %s.", name, def.Name)
 	file.Func().Id(name).Params(jen.Err().Error()).Params(jen.Bool()).Block(
-		jen.If(jen.Err().Op("==").Nil()).Block(jen.Return(jen.False())),
-		jen.List(jen.Id("_"), jen.Id("ok")).Op(":=").Add(snip.CGRErrorsGetConjureError()).Call(jen.Err()).Assert(jen.Op("*").Id(def.Name)),
-		jen.Return(jen.Id("ok")),
+		jen.Id("cErr").Op(":=").Add(snip.CGRErrorsGetConjureError()).Call(jen.Err()),
+		jen.Return(jen.Id("cErr").Op("!=").Nil().
+			Op("&&").
+			Id("cErr").Dot("Name").Call().Op("==").Lit(fmt.Sprintf("%s:%s", def.ErrorNamespace, def.Name))),
 	)
 }
 

--- a/cycles/testdata/cycle-within-pkg/conjure/com/palantir/errors/errors.conjure.go
+++ b/cycles/testdata/cycle-within-pkg/conjure/com/palantir/errors/errors.conjure.go
@@ -79,11 +79,8 @@ type MyError struct {
 
 // IsMyError returns true if err is an instance of MyError.
 func IsMyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyError)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "Namespace:MyError"
 }
 
 func (e *MyError) Error() string {

--- a/cycles/testdata/no-cycles/conjure/com/palantir/errors/errors.conjure.go
+++ b/cycles/testdata/no-cycles/conjure/com/palantir/errors/errors.conjure.go
@@ -79,11 +79,8 @@ type MyError struct {
 
 // IsMyError returns true if err is an instance of MyError.
 func IsMyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyError)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "Namespace:MyError"
 }
 
 func (e *MyError) Error() string {

--- a/cycles/testdata/pkg-cycle-disconnected/conjure/com/palantir/errors/errors.conjure.go
+++ b/cycles/testdata/pkg-cycle-disconnected/conjure/com/palantir/errors/errors.conjure.go
@@ -79,11 +79,8 @@ type MyError struct {
 
 // IsMyError returns true if err is an instance of MyError.
 func IsMyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyError)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "Namespace:MyError"
 }
 
 func (e *MyError) Error() string {

--- a/cycles/testdata/pkg-cycle/conjure/com/palantir/errors/errors.conjure.go
+++ b/cycles/testdata/pkg-cycle/conjure/com/palantir/errors/errors.conjure.go
@@ -79,11 +79,8 @@ type MyError struct {
 
 // IsMyError returns true if err is an instance of MyError.
 func IsMyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyError)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "Namespace:MyError"
 }
 
 func (e *MyError) Error() string {

--- a/cycles/testdata/type-cycle/conjure/com/palantir/errors/errors.conjure.go
+++ b/cycles/testdata/type-cycle/conjure/com/palantir/errors/errors.conjure.go
@@ -80,11 +80,8 @@ type MyError struct {
 
 // IsMyError returns true if err is an instance of MyError.
 func IsMyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyError)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "Namespace:MyError"
 }
 
 func (e *MyError) Error() string {

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -85,11 +85,8 @@ type MyInternal struct {
 
 // IsMyInternal returns true if err is an instance of MyInternal.
 func IsMyInternal(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyInternal)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "MyNamespace:MyInternal"
 }
 
 func (e *MyInternal) Error() string {
@@ -263,11 +260,8 @@ type MyNotFound struct {
 
 // IsMyNotFound returns true if err is an instance of MyNotFound.
 func IsMyNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := errors.GetConjureError(err).(*MyNotFound)
-	return ok
+	cErr := errors.GetConjureError(err)
+	return cErr != nil && cErr.Name() == "MyNamespace:MyNotFound"
 }
 
 func (e *MyNotFound) Error() string {


### PR DESCRIPTION
Since we stopped registering types in a global registry (#636), callers are more likely to encounter a genericError implementation of their error. We can avoid this somewhat by matching by Name() rather than go type in the generated boolean checker functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/643)
<!-- Reviewable:end -->
