### PR TITLE
improvement: Tag optional struct fields with 'omitempty' to skip null values

### DIFF
--- a/changelog/@unreleased/pr-703.v2.yml
+++ b/changelog/@unreleased/pr-703.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tag optional struct fields with 'omitempty' to skip null values
+  links:
+  - https://github.com/palantir/conjure-go/pull/703

--- a/conjure-api/conjure/spec/structs.conjure.go
+++ b/conjure-api/conjure/spec/structs.conjure.go
@@ -10,8 +10,8 @@ import (
 type AliasDefinition struct {
 	TypeName TypeName       `json:"typeName"`
 	Alias    Type           `json:"alias"`
-	Docs     *Documentation `json:"docs"`
-	Safety   *LogSafety     `json:"safety"`
+	Docs     *Documentation `json:"docs,omitempty"`
+	Safety   *LogSafety     `json:"safety,omitempty"`
 }
 
 func (o AliasDefinition) MarshalYAML() (interface{}, error) {
@@ -34,8 +34,8 @@ type ArgumentDefinition struct {
 	ArgName   ArgumentName   `json:"argName"`
 	Type      Type           `json:"type"`
 	ParamType ParameterType  `json:"paramType"`
-	Safety    *LogSafety     `json:"safety"`
-	Docs      *Documentation `json:"docs"`
+	Safety    *LogSafety     `json:"safety,omitempty"`
+	Docs      *Documentation `json:"docs,omitempty"`
 	Markers   []Type         `json:"markers"`
 	Tags      []string       `json:"tags"`
 }
@@ -188,11 +188,11 @@ type EndpointDefinition struct {
 	EndpointName EndpointName         `json:"endpointName"`
 	HttpMethod   HttpMethod           `json:"httpMethod"`
 	HttpPath     HttpPath             `json:"httpPath"`
-	Auth         *AuthType            `json:"auth"`
+	Auth         *AuthType            `json:"auth,omitempty"`
 	Args         []ArgumentDefinition `json:"args"`
-	Returns      *Type                `json:"returns"`
-	Docs         *Documentation       `json:"docs"`
-	Deprecated   *Documentation       `json:"deprecated"`
+	Returns      *Type                `json:"returns,omitempty"`
+	Docs         *Documentation       `json:"docs,omitempty"`
+	Deprecated   *Documentation       `json:"deprecated,omitempty"`
 	Markers      []Type               `json:"markers"`
 	Tags         []string             `json:"tags"`
 }
@@ -249,7 +249,7 @@ func (o *EndpointDefinition) UnmarshalYAML(unmarshal func(interface{}) error) er
 type EnumDefinition struct {
 	TypeName TypeName              `json:"typeName"`
 	Values   []EnumValueDefinition `json:"values"`
-	Docs     *Documentation        `json:"docs"`
+	Docs     *Documentation        `json:"docs,omitempty"`
 }
 
 func (o EnumDefinition) MarshalJSON() ([]byte, error) {
@@ -291,8 +291,8 @@ func (o *EnumDefinition) UnmarshalYAML(unmarshal func(interface{}) error) error 
 
 type EnumValueDefinition struct {
 	Value      string         `json:"value"`
-	Docs       *Documentation `json:"docs"`
-	Deprecated *Documentation `json:"deprecated"`
+	Docs       *Documentation `json:"docs,omitempty"`
+	Deprecated *Documentation `json:"deprecated,omitempty"`
 }
 
 func (o EnumValueDefinition) MarshalYAML() (interface{}, error) {
@@ -313,7 +313,7 @@ func (o *EnumValueDefinition) UnmarshalYAML(unmarshal func(interface{}) error) e
 
 type ErrorDefinition struct {
 	ErrorName  TypeName          `json:"errorName"`
-	Docs       *Documentation    `json:"docs"`
+	Docs       *Documentation    `json:"docs,omitempty"`
 	Namespace  ErrorNamespace    `json:"namespace"`
 	Code       ErrorCode         `json:"code"`
 	SafeArgs   []FieldDefinition `json:"safeArgs"`
@@ -389,9 +389,9 @@ func (o *ExternalReference) UnmarshalYAML(unmarshal func(interface{}) error) err
 type FieldDefinition struct {
 	FieldName  FieldName      `json:"fieldName"`
 	Type       Type           `json:"type"`
-	Docs       *Documentation `json:"docs"`
-	Deprecated *Documentation `json:"deprecated"`
-	Safety     *LogSafety     `json:"safety"`
+	Docs       *Documentation `json:"docs,omitempty"`
+	Deprecated *Documentation `json:"deprecated,omitempty"`
+	Safety     *LogSafety     `json:"safety,omitempty"`
 }
 
 func (o FieldDefinition) MarshalYAML() (interface{}, error) {
@@ -492,7 +492,7 @@ func (o *MapType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type ObjectDefinition struct {
 	TypeName TypeName          `json:"typeName"`
 	Fields   []FieldDefinition `json:"fields"`
-	Docs     *Documentation    `json:"docs"`
+	Docs     *Documentation    `json:"docs,omitempty"`
 }
 
 func (o ObjectDefinition) MarshalJSON() ([]byte, error) {
@@ -593,7 +593,7 @@ func (o *QueryParameterType) UnmarshalYAML(unmarshal func(interface{}) error) er
 type ServiceDefinition struct {
 	ServiceName TypeName             `json:"serviceName"`
 	Endpoints   []EndpointDefinition `json:"endpoints"`
-	Docs        *Documentation       `json:"docs"`
+	Docs        *Documentation       `json:"docs,omitempty"`
 }
 
 func (o ServiceDefinition) MarshalJSON() ([]byte, error) {
@@ -679,7 +679,7 @@ func (o *TypeName) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type UnionDefinition struct {
 	TypeName TypeName          `json:"typeName"`
 	Union    []FieldDefinition `json:"union"`
-	Docs     *Documentation    `json:"docs"`
+	Docs     *Documentation    `json:"docs,omitempty"`
 }
 
 func (o UnionDefinition) MarshalJSON() ([]byte, error) {

--- a/conjure-go-verifier/conjure/verification/types/structs.conjure.go
+++ b/conjure-go-verifier/conjure/verification/types/structs.conjure.go
@@ -252,7 +252,7 @@ func (o *ListExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type LongFieldNameOptionalExample struct {
-	SomeLongName *string `json:"someLongName"`
+	SomeLongName *string `json:"someLongName,omitempty"`
 }
 
 func (o LongFieldNameOptionalExample) MarshalYAML() (interface{}, error) {
@@ -316,7 +316,7 @@ type ObjectExample struct {
 	String       string             `json:"string"`
 	Integer      int                `json:"integer"`
 	DoubleValue  float64            `json:"doubleValue"`
-	OptionalItem *string            `json:"optionalItem"`
+	OptionalItem *string            `json:"optionalItem,omitempty"`
 	Items        []string           `json:"items"`
 	Set          []string           `json:"set"`
 	Map          map[string]string  `json:"map"`
@@ -373,7 +373,7 @@ func (o *ObjectExample) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type OptionalBooleanExample struct {
-	Value *bool `json:"value"`
+	Value *bool `json:"value,omitempty"`
 }
 
 func (o OptionalBooleanExample) MarshalYAML() (interface{}, error) {
@@ -393,7 +393,7 @@ func (o *OptionalBooleanExample) UnmarshalYAML(unmarshal func(interface{}) error
 }
 
 type OptionalExample struct {
-	Value *string `json:"value"`
+	Value *string `json:"value,omitempty"`
 }
 
 func (o OptionalExample) MarshalYAML() (interface{}, error) {
@@ -413,7 +413,7 @@ func (o *OptionalExample) UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
 type OptionalIntegerExample struct {
-	Value *int `json:"value"`
+	Value *int `json:"value,omitempty"`
 }
 
 func (o OptionalIntegerExample) MarshalYAML() (interface{}, error) {

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -34,6 +34,9 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 	file.Add(objectDef.Docs.CommentLine()).Type().Id(objectDef.Name).StructFunc(func(structDecl *jen.Group) {
 		for _, fieldDef := range objectDef.Fields {
 			fieldName := fieldDef.Name
+			if _, isOptional := fieldDef.Type.(*types.Optional); isOptional {
+				fieldName += ",omitempty"
+			}
 			fieldTags := map[string]string{"json": fieldName}
 
 			if fieldDef.Docs != "" {
@@ -45,7 +48,7 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 			if fieldDef.Type.Make() != nil {
 				containsCollection = true
 			}
-			structDecl.Add(fieldDef.Docs.CommentLineWithDeprecation(fieldDef.Deprecated)).Id(transforms.ExportedFieldName(fieldName)).Add(fieldDef.Type.Code()).Tag(fieldTags)
+			structDecl.Add(fieldDef.Docs.CommentLineWithDeprecation(fieldDef.Deprecated)).Id(transforms.ExportedFieldName(fieldDef.Name)).Add(fieldDef.Type.Code()).Tag(fieldTags)
 		}
 	})
 

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -33,11 +33,11 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 	containsCollection := false // If contains collection, we need JSON methods to initialize empty values.
 	file.Add(objectDef.Docs.CommentLine()).Type().Id(objectDef.Name).StructFunc(func(structDecl *jen.Group) {
 		for _, fieldDef := range objectDef.Fields {
-			fieldName := fieldDef.Name
+			jsonTag := fieldDef.Name
 			if _, isOptional := fieldDef.Type.(*types.Optional); isOptional {
-				fieldName += ",omitempty"
+				jsonTag += ",omitempty"
 			}
-			fieldTags := map[string]string{"json": fieldName}
+			fieldTags := map[string]string{"json": jsonTag}
 
 			if fieldDef.Docs != "" {
 				// backtick characters ("`") are really painful to deal with in struct tags

--- a/integration_test/testgenerated/binary/api/structs.conjure.go
+++ b/integration_test/testgenerated/binary/api/structs.conjure.go
@@ -9,7 +9,7 @@ import (
 
 type CustomObject struct {
 	Data        []byte       `json:"data"`
-	BinaryAlias *BinaryAlias `json:"binaryAlias"`
+	BinaryAlias *BinaryAlias `json:"binaryAlias,omitempty"`
 }
 
 func (o CustomObject) MarshalYAML() (interface{}, error) {

--- a/integration_test/testgenerated/errors/api/errors.conjure.go
+++ b/integration_test/testgenerated/errors/api/errors.conjure.go
@@ -23,7 +23,7 @@ type myInternal struct {
 	// A field named with a go keyword
 	Type       string  `conjure-docs:"A field named with a go keyword" json:"type"`
 	UnsafeArgA string  `json:"unsafeArgA"`
-	UnsafeArgB *string `json:"unsafeArgB"`
+	UnsafeArgB *string `json:"unsafeArgB,omitempty"`
 	MyInternal string  `json:"myInternal"`
 }
 
@@ -202,7 +202,7 @@ type myNotFound struct {
 	// A field named with a go keyword
 	Type       string  `conjure-docs:"A field named with a go keyword" json:"type"`
 	UnsafeArgA string  `json:"unsafeArgA"`
-	UnsafeArgB *string `json:"unsafeArgB"`
+	UnsafeArgB *string `json:"unsafeArgB,omitempty"`
 }
 
 func (o myNotFound) MarshalJSON() ([]byte, error) {

--- a/integration_test/testgenerated/errors/errors_test.go
+++ b/integration_test/testgenerated/errors/errors_test.go
@@ -58,8 +58,7 @@ var testJSON = fmt.Sprintf(`{
       3
     ],
     "type": "type",
-    "unsafeArgA": "something",
-    "unsafeArgB": null
+    "unsafeArgA": "something"
   }
 }`, testError.InstanceID())
 

--- a/integration_test/testgenerated/objects/api/structs.conjure.go
+++ b/integration_test/testgenerated/objects/api/structs.conjure.go
@@ -326,8 +326,8 @@ func (o *MapStringAnyObject) UnmarshalYAML(unmarshal func(interface{}) error) er
 }
 
 type OptionalFields struct {
-	Opt1 *string           `json:"opt1"`
-	Opt2 *string           `json:"opt2"`
+	Opt1 *string           `json:"opt1,omitempty"`
+	Opt2 *string           `json:"opt2,omitempty"`
 	Reqd string            `json:"reqd"`
 	Opt3 OptionalUuidAlias `json:"opt3"`
 }


### PR DESCRIPTION
Per the conjure specification, these fields may be omitted and clutter JSON payloads unnecessarily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/703)
<!-- Reviewable:end -->
