### PR TITLE
Generate log safety struct tags for safelogging lint

### DIFF
--- a/conjure/aliaswriter_test.go
+++ b/conjure/aliaswriter_test.go
@@ -15,9 +15,11 @@
 package conjure
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/palantir/conjure-go/v6/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/v6/conjure/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -171,6 +173,253 @@ func TestAliasWriter(t *testing.T) {
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			assert.Equal(t, test.Out, test.In.GoString())
+		})
+	}
+}
+
+func TestWriteAliasTypeWithSafety(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   *types.AliasType
+		out  string
+	}{
+		{
+			name: "Simple alias without safety annotation",
+			in: &types.AliasType{
+				Name: "StringAlias",
+				Item: types.String{},
+			},
+			out: `package testpkg
+
+type StringAlias string
+`,
+		},
+		{
+			name: "Simple alias with unsafe safety annotation",
+			in: types.NewAliasTypeWithSafety("UnsafeStringAlias", types.String{},
+				func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }()),
+			out: `package testpkg
+
+type UnsafeStringAlias string // safelogging:@Unsafe
+`,
+		},
+		{
+			name: "Simple alias with safe safety annotation",
+			in: types.NewAliasTypeWithSafety("SafeStringAlias", types.String{},
+				func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+			out: `package testpkg
+
+type SafeStringAlias string // safelogging:@Safe
+`,
+		},
+		{
+			name: "Simple alias with do-not-log safety annotation",
+			in: types.NewAliasTypeWithSafety("SecretStringAlias", types.String{},
+				func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_DO_NOT_LOG); return &s }()),
+			out: `package testpkg
+
+type SecretStringAlias string // safelogging:@DoNotLog
+`,
+		},
+		{
+			name: "Alias with documentation and safety annotation",
+			in: func() *types.AliasType {
+				alias := types.NewAliasTypeWithSafety("DocumentedUnsafeAlias", types.String{},
+					func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }())
+				alias.Docs = types.Docs("This is a documented unsafe alias.")
+				return alias
+			}(),
+			out: `package testpkg
+
+// This is a documented unsafe alias.
+type DocumentedUnsafeAlias string // safelogging:@Unsafe
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := jen.NewFile("testpkg")
+			writeAliasType(f.Group, tc.in)
+			var buf bytes.Buffer
+			assert.NoError(t, f.Render(&buf))
+			assert.Equal(t, tc.out, buf.String())
+		})
+	}
+}
+
+func TestWriteOptionalAliasTypeWithSafety(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   *types.AliasType
+		out  string
+	}{
+		{
+			name: "Optional alias with documentation only (no safety)",
+			in: func() *types.AliasType {
+				alias := &types.AliasType{
+					Name: "OptionalDocumentedAlias",
+					Item: &types.Optional{Item: types.String{}},
+				}
+				alias.Docs = types.Docs("This is an optional documented alias without safety annotation.")
+				return alias
+			}(),
+			out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// This is an optional documented alias without safety annotation.
+type OptionalDocumentedAlias struct {
+	Value *string
+}
+
+func (a OptionalDocumentedAlias) MarshalText() ([]byte, error) {
+	if a.Value == nil {
+		return nil, nil
+	}
+	return []byte(*a.Value), nil
+}
+func (a OptionalDocumentedAlias) MarshalJSON() ([]byte, error) {
+	if a.Value == nil {
+		return []byte("null"), nil
+	}
+	return safejson.Marshal(a.Value)
+}
+func (a *OptionalDocumentedAlias) UnmarshalText(data []byte) error {
+	rawOptionalDocumentedAlias := string(data)
+	a.Value = &rawOptionalDocumentedAlias
+	return nil
+}
+func (a OptionalDocumentedAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (a *OptionalDocumentedAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+`,
+		},
+		{
+			name: "Optional alias with safety only (no documentation)",
+			in: func() *types.AliasType {
+				alias := types.NewAliasTypeWithSafety("OptionalUnsafeAlias", &types.Optional{Item: types.String{}},
+					func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }())
+				return alias
+			}(),
+			out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@Unsafe
+type OptionalUnsafeAlias struct {
+	Value *string
+}
+
+func (a OptionalUnsafeAlias) MarshalText() ([]byte, error) {
+	if a.Value == nil {
+		return nil, nil
+	}
+	return []byte(*a.Value), nil
+}
+func (a OptionalUnsafeAlias) MarshalJSON() ([]byte, error) {
+	if a.Value == nil {
+		return []byte("null"), nil
+	}
+	return safejson.Marshal(a.Value)
+}
+func (a *OptionalUnsafeAlias) UnmarshalText(data []byte) error {
+	rawOptionalUnsafeAlias := string(data)
+	a.Value = &rawOptionalUnsafeAlias
+	return nil
+}
+func (a OptionalUnsafeAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (a *OptionalUnsafeAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+`,
+		},
+		{
+			name: "Optional alias with both documentation and safety",
+			in: func() *types.AliasType {
+				alias := types.NewAliasTypeWithSafety("OptionalDocumentedUnsafeAlias", &types.Optional{Item: types.String{}},
+					func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }())
+				alias.Docs = types.Docs("This is an optional documented unsafe alias.")
+				return alias
+			}(),
+			out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// This is an optional documented unsafe alias.
+// safelogging:@Unsafe
+type OptionalDocumentedUnsafeAlias struct {
+	Value *string
+}
+
+func (a OptionalDocumentedUnsafeAlias) MarshalText() ([]byte, error) {
+	if a.Value == nil {
+		return nil, nil
+	}
+	return []byte(*a.Value), nil
+}
+func (a OptionalDocumentedUnsafeAlias) MarshalJSON() ([]byte, error) {
+	if a.Value == nil {
+		return []byte("null"), nil
+	}
+	return safejson.Marshal(a.Value)
+}
+func (a *OptionalDocumentedUnsafeAlias) UnmarshalText(data []byte) error {
+	rawOptionalDocumentedUnsafeAlias := string(data)
+	a.Value = &rawOptionalDocumentedUnsafeAlias
+	return nil
+}
+func (a OptionalDocumentedUnsafeAlias) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (a *OptionalDocumentedUnsafeAlias) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&a)
+}
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := jen.NewFile("testpkg")
+			writeOptionalAliasType(f.Group, tc.in)
+			var buf bytes.Buffer
+			assert.NoError(t, f.Render(&buf))
+			assert.Equal(t, tc.out, buf.String())
 		})
 	}
 }

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -82,8 +82,9 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 		}
 		if len(pkg.Objects) > 0 {
 			objectFile := newJenFile(pkg, def, errorRegistryImportPath)
+			safetyCache := make(map[types.Type]spec.LogSafety)
 			for _, object := range pkg.Objects {
-				writeObjectType(objectFile.Group, object)
+				writeObjectType(objectFile.Group, object, safetyCache)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "structs.conjure.go"), objectFile))
 		}

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -59,7 +59,8 @@ func writeErrorType(file *jen.Group, def *types.ErrorDefinition) {
 func astErrorInternalStructType(file *jen.Group, def *types.ErrorDefinition) {
 	allArgs := append(append([]*types.Field{}, def.SafeArgs...), def.UnsafeArgs...)
 	// Use object generator to create a struct implementing JSON encoding for the error.
-	writeObjectType(file, &types.ObjectType{Name: transforms.Private(def.Name), Fields: allArgs})
+	safetyCache := make(map[types.Type]spec.LogSafety)
+	writeObjectType(file, &types.ObjectType{Name: transforms.Private(def.Name), Fields: allArgs}, safetyCache)
 }
 
 // Declare New and Wrap constructors

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/palantir/conjure-go/v6/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/v6/conjure/snip"
 	"github.com/palantir/conjure-go/v6/conjure/transforms"
 	"github.com/palantir/conjure-go/v6/conjure/types"
@@ -28,10 +29,32 @@ const (
 	dataVarName     = "data"
 )
 
-func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
+// logSafetyToAnnotation converts a LogSafety value to its corresponding safelogging annotation string
+func logSafetyToAnnotation(safety spec.LogSafety_Value) string {
+	switch safety {
+	case spec.LogSafety_SAFE:
+		return "@Safe"
+	case spec.LogSafety_UNSAFE:
+		return "@Unsafe"
+	case spec.LogSafety_DO_NOT_LOG:
+		return "@DoNotLog"
+	default:
+		panic("unhandled LogSafety value: " + safety)
+	}
+}
+
+func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache map[types.Type]spec.LogSafety) {
 	// Declare struct type with fields
 	containsCollection := false // If contains collection, we need JSON methods to initialize empty values.
-	file.Add(objectDef.Docs.CommentLine()).Type().Id(objectDef.Name).StructFunc(func(structDecl *jen.Group) {
+
+	// Compute the overall safety of the struct and add comment-based annotation
+	overallSafety := computeObjectSafety(objectDef, safetyCache)
+	var safetyComment jen.Code = jen.Null()
+	if !overallSafety.IsUnknown() {
+		safetyComment = jen.Comment("safelogging:" + logSafetyToAnnotation(overallSafety.Value()))
+	}
+
+	structFunc := func(structDecl *jen.Group) {
 		for _, fieldDef := range objectDef.Fields {
 			jsonTag := fieldDef.Name
 			if _, isOptional := fieldDef.Type.(*types.Optional); isOptional {
@@ -45,12 +68,25 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 				// double quotes instead.
 				fieldTags["conjure-docs"] = strings.Replace(strings.TrimSpace(string(fieldDef.Docs)), "`", `"`, -1)
 			}
+
+			// Add safety struct tag based on field's safety annotation or type safety (with recursive computation)
+			fieldSafety := getSafetyFromField(fieldDef, safetyCache)
+			if !fieldSafety.IsUnknown() {
+				fieldTags["safelogging"] = logSafetyToAnnotation(fieldSafety.Value())
+			}
 			if fieldDef.Type.Make() != nil {
 				containsCollection = true
 			}
 			structDecl.Add(fieldDef.Docs.CommentLineWithDeprecation(fieldDef.Deprecated)).Id(transforms.ExportedFieldName(fieldDef.Name)).Add(fieldDef.Type.Code()).Tag(fieldTags)
 		}
-	})
+	}
+
+	// If there are docs, add them without the trailing line since the safety comment will alreaady add the trailing line
+	if objectDef.Docs != "" {
+		file.Comment(string(objectDef.Docs))
+	}
+	file.Add(safetyComment)
+	file.Type().Id(objectDef.Name).StructFunc(structFunc)
 
 	// If there are no collections, we can defer to the default json behavior
 	// Otherwise we need to override MarshalJSON and UnmarshalJSON
@@ -92,4 +128,86 @@ func writeStructMarshalInitDecls(methodBody *jen.Group, fields []*types.Field, r
 			)
 		}
 	}
+}
+
+func getSafetyFromType(fieldType types.Type, safetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	if safetyCache == nil {
+		safetyCache = make(map[types.Type]spec.LogSafety)
+	}
+
+	// Check cache first
+	if cached, exists := safetyCache[fieldType]; exists {
+		return cached
+	}
+
+	// Insert placeholder to detect cycles - use UNKNOWN as safe default
+	safetyCache[fieldType] = spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+
+	// First check if the field type itself has safety annotations
+	fieldSafety := fieldType.Safety()
+	if !fieldSafety.IsUnknown() {
+		// Update cache with real result
+		safetyCache[fieldType] = fieldSafety
+		return fieldSafety
+	}
+
+	// If it's an ObjectType, recursively compute safety from its fields
+	if objectType, ok := fieldType.(*types.ObjectType); ok {
+		result := computeObjectSafety(objectType, safetyCache)
+		// Update cache with computed result
+		safetyCache[fieldType] = result
+		return result
+	}
+
+	// For other types without explicit safety, return unknown so no tags are added
+	// Cache already contains UNKNOWN, so just return it
+	return spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+}
+
+// getSafetyFromField returns the safety of a field, considering both field-level and type-level safety annotations
+func getSafetyFromField(field *types.Field, safetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	// First check if the field has an explicit safety annotation
+	if field.Safety != nil {
+		return *field.Safety
+	}
+	// Fall back to type-based safety
+	return getSafetyFromType(field.Type, safetyCache)
+}
+
+func computeObjectSafety(object *types.ObjectType, typeSafetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	// Empty struct has no information to determine safety, so it should be unknown
+	if len(object.Fields) == 0 {
+		return spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+	}
+
+	// Default to SAFE, then find the most restrictive level
+	// Hierarchy: safe -> unannotated -> unsafe -> do-not-log
+	overallSafety := spec.New_LogSafety(spec.LogSafety_SAFE)
+
+	for _, fieldDef := range object.Fields {
+		fieldSafety := getSafetyFromField(fieldDef, typeSafetyCache)
+
+		if fieldSafety.IsUnknown() {
+			// Field for which safety cannot be determined "contaminates" the struct - it becomes unannotated
+			// unless we already found something more restrictive
+			if overallSafety.Value() == spec.LogSafety_SAFE {
+				overallSafety = spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+			}
+		} else {
+			// Specific safety value determined for field
+			switch fieldSafety.Value() {
+			case spec.LogSafety_DO_NOT_LOG:
+				return fieldSafety // Most restrictive, return immediately
+			case spec.LogSafety_UNSAFE:
+				if overallSafety.Value() == spec.LogSafety_SAFE || overallSafety.IsUnknown() {
+					overallSafety = fieldSafety
+				}
+			case spec.LogSafety_SAFE:
+				// SAFE is least restrictive, only set if we haven't found anything else
+				// (overallSafety is already SAFE by default)
+			}
+		}
+	}
+
+	return overallSafety
 }

--- a/conjure/objectwriter_test.go
+++ b/conjure/objectwriter_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/palantir/conjure-go/v6/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/v6/conjure/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -132,10 +133,429 @@ func (o *User) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 `,
 		},
+		{
+			name: "Object with safety annotations",
+			in: &types.ObjectType{
+				Name: "SafetyTestObject",
+				Fields: []*types.Field{
+					{
+						Name: "safeField",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "unsafeField",
+						Type: types.NewAliasTypeWithSafety("UnsafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }()),
+					},
+					{
+						Name: "doNotLogField",
+						Type: types.NewAliasTypeWithSafety("SecretString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_DO_NOT_LOG); return &s }()),
+					},
+					{
+						Name: "normalField",
+						Type: types.String{},
+					},
+					{
+						Name:   "fieldLevelSafeString",
+						Type:   types.String{},
+						Safety: func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }(),
+					},
+					{
+						Name:   "fieldLevelUnsafeString",
+						Type:   types.String{},
+						Safety: func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }(),
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@DoNotLog
+type SafetyTestObject struct {
+	SafeField              SafeString   ` + "`json:\"safeField\" safelogging:\"@Safe\"`" + `
+	UnsafeField            UnsafeString ` + "`json:\"unsafeField\" safelogging:\"@Unsafe\"`" + `
+	DoNotLogField          SecretString ` + "`json:\"doNotLogField\" safelogging:\"@DoNotLog\"`" + `
+	NormalField            string       ` + "`json:\"normalField\"`" + `
+	FieldLevelSafeString   string       ` + "`json:\"fieldLevelSafeString\" safelogging:\"@Safe\"`" + `
+	FieldLevelUnsafeString string       ` + "`json:\"fieldLevelUnsafeString\" safelogging:\"@Unsafe\"`" + `
+}
+
+func (o SafetyTestObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *SafetyTestObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with only safe fields",
+			in: &types.ObjectType{
+				Name: "OnlySafeObject",
+				Fields: []*types.Field{
+					{
+						Name: "safeField1",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "safeField2",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "normalField",
+						Type: types.String{},
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+type OnlySafeObject struct {
+	SafeField1  SafeString ` + "`json:\"safeField1\" safelogging:\"@Safe\"`" + `
+	SafeField2  SafeString ` + "`json:\"safeField2\" safelogging:\"@Safe\"`" + `
+	NormalField string     ` + "`json:\"normalField\"`" + `
+}
+
+func (o OnlySafeObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *OnlySafeObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with unsafe but no do-not-log fields",
+			in: &types.ObjectType{
+				Name: "UnsafeObject",
+				Fields: []*types.Field{
+					{
+						Name: "safeField",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "unsafeField",
+						Type: types.NewAliasTypeWithSafety("UnsafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }()),
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@Unsafe
+type UnsafeObject struct {
+	SafeField   SafeString   ` + "`json:\"safeField\" safelogging:\"@Safe\"`" + `
+	UnsafeField UnsafeString ` + "`json:\"unsafeField\" safelogging:\"@Unsafe\"`" + `
+}
+
+func (o UnsafeObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *UnsafeObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Nested objects with different safety levels",
+			in: &types.ObjectType{
+				Name: "RootObject",
+				Fields: []*types.Field{
+					{
+						Name: "foo",
+						Type: &types.ObjectType{
+							Name: "Foo",
+							Fields: []*types.Field{
+								{
+									Name: "safeField1",
+									Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+										func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+								},
+								{
+									Name: "safeField2",
+									Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+										func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+								},
+							},
+						},
+					},
+					{
+						Name: "bar",
+						Type: &types.ObjectType{
+							Name: "Bar",
+							Fields: []*types.Field{
+								{
+									Name: "safeField",
+									Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+										func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+								},
+								{
+									Name: "unsafeField",
+									Type: types.NewAliasTypeWithSafety("UnsafeString", types.String{},
+										func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }()),
+								},
+							},
+						},
+					},
+					{
+						Name: "qux",
+						Type: &types.ObjectType{
+							Name: "Qux",
+							Fields: []*types.Field{
+								{
+									Name: "safeField",
+									Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+										func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+								},
+								{
+									Name: "unannotatedField",
+									Type: types.String{}, // No safety annotation
+								},
+							},
+						},
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@Unsafe
+type RootObject struct {
+	Foo Foo ` + "`json:\"foo\" safelogging:\"@Safe\"`" + `
+	Bar Bar ` + "`json:\"bar\" safelogging:\"@Unsafe\"`" + `
+	Qux Qux ` + "`json:\"qux\"`" + `
+}
+
+func (o RootObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *RootObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with mix of safe and unannotated fields",
+			in: &types.ObjectType{
+				Name: "MixedSafetyObject",
+				Fields: []*types.Field{
+					{
+						Name: "safeField",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "unannotatedField",
+						Type: types.String{}, // No safety annotation
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+type MixedSafetyObject struct {
+	SafeField        SafeString ` + "`json:\"safeField\" safelogging:\"@Safe\"`" + `
+	UnannotatedField string     ` + "`json:\"unannotatedField\"`" + `
+}
+
+func (o MixedSafetyObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *MixedSafetyObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Empty struct should have unknown safety",
+			in: &types.ObjectType{
+				Name:   "EmptyStruct",
+				Fields: []*types.Field{}, // No fields
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+type EmptyStruct struct{}
+
+func (o EmptyStruct) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *EmptyStruct) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with docs and safety annotation",
+			in: &types.ObjectType{
+				Name: "DocumentedSafeObject",
+				Docs: types.Docs("DocumentedSafeObject represents a safe object with documentation."),
+				Fields: []*types.Field{
+					{
+						Name: "safeField",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// DocumentedSafeObject represents a safe object with documentation.
+// safelogging:@Safe
+type DocumentedSafeObject struct {
+	SafeField SafeString ` + "`json:\"safeField\" safelogging:\"@Safe\"`" + `
+}
+
+func (o DocumentedSafeObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *DocumentedSafeObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with docs but no safety annotation",
+			in: &types.ObjectType{
+				Name: "DocumentedMixedObject",
+				Docs: types.Docs("DocumentedMixedObject has mixed field safety levels."),
+				Fields: []*types.Field{
+					{
+						Name: "safeField",
+						Type: types.NewAliasTypeWithSafety("SafeString", types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }()),
+					},
+					{
+						Name: "normalField",
+						Type: types.String{}, // No safety annotation - makes struct unknown
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// DocumentedMixedObject has mixed field safety levels.
+type DocumentedMixedObject struct {
+	SafeField   SafeString ` + "`json:\"safeField\" safelogging:\"@Safe\"`" + `
+	NormalField string     ` + "`json:\"normalField\"`" + `
+}
+
+func (o DocumentedMixedObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *DocumentedMixedObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := jen.NewFile("testpkg")
-			writeObjectType(f.Group, tc.in)
+			safetyCache := make(map[types.Type]spec.LogSafety)
+			writeObjectType(f.Group, tc.in, safetyCache)
 			var buf bytes.Buffer
 			assert.NoError(t, f.Render(&buf))
 			assert.Equal(t, tc.Out, buf.String())

--- a/conjure/testdata/safety-tags-test.yml
+++ b/conjure/testdata/safety-tags-test.yml
@@ -1,0 +1,74 @@
+types:
+  definitions:
+    default-package: test.safety
+    objects:
+      SafetyTestObject:
+        fields:
+          safeField:
+            type: string
+            safety: safe
+          unsafeField:
+            type: string
+            safety: unsafe
+          doNotLogField:
+            type: string
+            safety: do-not-log
+          normalField:
+            type: string
+          safeIntegerField:
+            type: integer
+            safety: safe
+      SafeAlias:
+        alias: string
+        safety: safe
+      UnsafeAlias:
+        alias: string
+        safety: unsafe
+      DoNotLogAlias:
+        alias: string
+        safety: do-not-log
+      NestedSafetyObject:
+        fields:
+          safeData: SafeAlias
+          unsafeData: UnsafeAlias
+          secretData: DoNotLogAlias
+      ListSafetyObject:
+        fields:
+          safeList:
+            type: list<SafeAlias>
+          unsafeList:
+            type: list<UnsafeAlias>
+          doNotLogList:
+            type: list<DoNotLogAlias>
+          normalList:
+            type: list<string>
+      SetSafetyObject:
+        fields:
+          safeSet:
+            type: set<SafeAlias>
+          unsafeSet:
+            type: set<UnsafeAlias>
+          doNotLogSet:
+            type: set<DoNotLogAlias>
+          normalSet:
+            type: set<string>
+      MapSafetyObject:
+        fields:
+          safeKeyValueMap:
+            type: map<SafeAlias, SafeAlias>
+          unsafeKeyMap:
+            type: map<UnsafeAlias, SafeAlias>
+          unsafeValueMap:
+            type: map<SafeAlias, UnsafeAlias>
+          doNotLogKeyMap:
+            type: map<DoNotLogAlias, SafeAlias>
+          doNotLogValueMap:
+            type: map<SafeAlias, DoNotLogAlias>
+          normalMap:
+            type: map<string, string>
+      InheritedSafetyAlias:
+        alias: SafeAlias
+      InheritedUnsafetyAlias:
+        alias: UnsafeAlias
+      InheritedDoNotLogAlias:
+        alias: DoNotLogAlias

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -19,7 +19,6 @@ import (
 	"path"
 	"regexp"
 	"strings"
-	"sync"
 	"unicode"
 
 	"github.com/dave/jennifer/jen"
@@ -394,14 +393,12 @@ func (t *namedTypes) markComplete(pkg, name string) {
 func newFields(names *namedTypes, structDefs []spec.FieldDefinition, enumDefs []spec.EnumValueDefinition) []*Field {
 	var fields []*Field
 	for _, value := range structDefs {
-		if value.Safety != nil {
-			logSafetyWarning()
-		}
 		fields = append(fields, &Field{
 			Docs:       Docs(transforms.Documentation(value.Docs)),
 			Deprecated: Docs(transforms.Documentation(value.Deprecated)),
 			Name:       string(value.FieldName),
 			Type:       names.GetBySpec(value.Type),
+			Safety:     value.Safety,
 		})
 	}
 	for _, value := range enumDefs {
@@ -532,12 +529,4 @@ func sanitizePackageName(importPath string) string {
 	}
 
 	return alias
-}
-
-var logSafetyWarningOnce sync.Once
-
-func logSafetyWarning() {
-	logSafetyWarningOnce.Do(func() {
-		fmt.Println("Warning: Object definition(s) use 'safety' fields unimplemented by conjure-go.")
-	})
 }

--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -216,6 +216,15 @@ type AliasType struct {
 	base
 }
 
+// NewAliasTypeWithSafety creates an AliasType with safety annotation
+func NewAliasTypeWithSafety(name string, item Type, safety *spec.LogSafety) *AliasType {
+	return &AliasType{
+		Name:   name,
+		Item:   item,
+		safety: safety,
+	}
+}
+
 func (t *AliasType) Code() *jen.Statement {
 	return jen.Qual(t.importPath, t.Name)
 }
@@ -366,6 +375,7 @@ type Field struct {
 	Deprecated Docs
 	Name       string // JSON key or enum value
 	Type       Type   // string for enum value
+	Safety     *spec.LogSafety
 }
 
 // private utility types

--- a/integration_test/testgenerated/server/api/aliases.conjure.go
+++ b/integration_test/testgenerated/server/api/aliases.conjure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/palantir/pkg/uuid"
 )
 
+// safelogging:@Safe
 type OptionalIntegerAlias struct {
 	Value *int
 }
@@ -76,7 +77,7 @@ func (a *OptionalListAlias) UnmarshalYAML(unmarshal func(interface{}) error) err
 	return safejson.Unmarshal(jsonBytes, *&a)
 }
 
-type SafeUuid uuid.UUID
+type SafeUuid uuid.UUID // safelogging:@Safe
 
 func (a SafeUuid) String() string {
 	return uuid.UUID(a).String()
@@ -111,4 +112,4 @@ func (a *SafeUuid) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return safejson.Unmarshal(jsonBytes, *&a)
 }
 
-type StringAlias string
+type StringAlias string // safelogging:@DoNotLog


### PR DESCRIPTION
Generate log safety struct tags for logger safety implementation

This implements the Go struct safety annotation support by adding
`safelogging` struct tags and comments to the generated Go structs.

```go
// safelogging:@DoNotLog
type SafetyTestObject struct {
    SafeField     SafeString   `safelogging:"@Safe" json:"safeField"`
    DoNotLogField SecretString `safelogging:"@DoNotLog" json:"doNotLogField"`
    NormalField   string       `json:"normalField"`
}
```

This will enable safelogging library to inspect struct field safety annotations
preventing security incidents.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Generate log safety struct tags for Go client safety implementation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/714)
<!-- Reviewable:end -->
