### PR TITLE
✨ AcceptFuncs support for generic unions

### DIFF
--- a/changelog/@unreleased/pr-725.v2.yml
+++ b/changelog/@unreleased/pr-725.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ✨ AcceptFuncs support for generic unions
+  links:
+  - https://github.com/palantir/conjure-go/pull/725

--- a/changelog/@unreleased/pr-725.v2.yml
+++ b/changelog/@unreleased/pr-725.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: ✨ AcceptFuncs support for generic unions
+  description: ✨ AcceptFuncs support for generic unions, conditionally added with
+    the same accept-funcs configuration that already exists for non-generic unions.
   links:
   - https://github.com/palantir/conjure-go/pull/725

--- a/conjure-api/conjure/spec/unions_generics.conjure.go
+++ b/conjure-api/conjure/spec/unions_generics.conjure.go
@@ -32,6 +32,42 @@ func (u *AuthTypeWithT[T]) Accept(ctx context.Context, v AuthTypeVisitorWithT[T]
 	}
 }
 
+func (u *AuthTypeWithT[T]) AcceptFuncs(headerFunc func(HeaderAuthType) (T, error), cookieFunc func(CookieAuthType) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "header":
+		if u.header == nil {
+			return result, fmt.Errorf("field \"header\" is required")
+		}
+		return headerFunc(*u.header)
+	case "cookie":
+		if u.cookie == nil {
+			return result, fmt.Errorf("field \"cookie\" is required")
+		}
+		return cookieFunc(*u.cookie)
+	}
+}
+
+func (u *AuthTypeWithT[T]) HeaderNoopSuccess(HeaderAuthType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *AuthTypeWithT[T]) CookieNoopSuccess(CookieAuthType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *AuthTypeWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type AuthTypeVisitorWithT[T any] interface {
 	VisitHeader(ctx context.Context, v HeaderAuthType) (T, error)
 	VisitCookie(ctx context.Context, v CookieAuthType) (T, error)
@@ -69,6 +105,62 @@ func (u *ParameterTypeWithT[T]) Accept(ctx context.Context, v ParameterTypeVisit
 		}
 		return v.VisitQuery(ctx, *u.query)
 	}
+}
+
+func (u *ParameterTypeWithT[T]) AcceptFuncs(bodyFunc func(BodyParameterType) (T, error), headerFunc func(HeaderParameterType) (T, error), pathFunc func(PathParameterType) (T, error), queryFunc func(QueryParameterType) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "body":
+		if u.body == nil {
+			return result, fmt.Errorf("field \"body\" is required")
+		}
+		return bodyFunc(*u.body)
+	case "header":
+		if u.header == nil {
+			return result, fmt.Errorf("field \"header\" is required")
+		}
+		return headerFunc(*u.header)
+	case "path":
+		if u.path == nil {
+			return result, fmt.Errorf("field \"path\" is required")
+		}
+		return pathFunc(*u.path)
+	case "query":
+		if u.query == nil {
+			return result, fmt.Errorf("field \"query\" is required")
+		}
+		return queryFunc(*u.query)
+	}
+}
+
+func (u *ParameterTypeWithT[T]) BodyNoopSuccess(BodyParameterType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ParameterTypeWithT[T]) HeaderNoopSuccess(HeaderParameterType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ParameterTypeWithT[T]) PathNoopSuccess(PathParameterType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ParameterTypeWithT[T]) QueryNoopSuccess(QueryParameterType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ParameterTypeWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
 }
 
 type ParameterTypeVisitorWithT[T any] interface {
@@ -127,6 +219,92 @@ func (u *TypeWithT[T]) Accept(ctx context.Context, v TypeVisitorWithT[T]) (T, er
 	}
 }
 
+func (u *TypeWithT[T]) AcceptFuncs(primitiveFunc func(PrimitiveType) (T, error), optionalFunc func(OptionalType) (T, error), listFunc func(ListType) (T, error), setFunc func(SetType) (T, error), map_Func func(MapType) (T, error), referenceFunc func(TypeName) (T, error), externalFunc func(ExternalReference) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "primitive":
+		if u.primitive == nil {
+			return result, fmt.Errorf("field \"primitive\" is required")
+		}
+		return primitiveFunc(*u.primitive)
+	case "optional":
+		if u.optional == nil {
+			return result, fmt.Errorf("field \"optional\" is required")
+		}
+		return optionalFunc(*u.optional)
+	case "list":
+		if u.list == nil {
+			return result, fmt.Errorf("field \"list\" is required")
+		}
+		return listFunc(*u.list)
+	case "set":
+		if u.set == nil {
+			return result, fmt.Errorf("field \"set\" is required")
+		}
+		return setFunc(*u.set)
+	case "map":
+		if u.map_ == nil {
+			return result, fmt.Errorf("field \"map\" is required")
+		}
+		return map_Func(*u.map_)
+	case "reference":
+		if u.reference == nil {
+			return result, fmt.Errorf("field \"reference\" is required")
+		}
+		return referenceFunc(*u.reference)
+	case "external":
+		if u.external == nil {
+			return result, fmt.Errorf("field \"external\" is required")
+		}
+		return externalFunc(*u.external)
+	}
+}
+
+func (u *TypeWithT[T]) PrimitiveNoopSuccess(PrimitiveType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) OptionalNoopSuccess(OptionalType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) ListNoopSuccess(ListType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) SetNoopSuccess(SetType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) MapNoopSuccess(MapType) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) ReferenceNoopSuccess(TypeName) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) ExternalNoopSuccess(ExternalReference) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type TypeVisitorWithT[T any] interface {
 	VisitPrimitive(ctx context.Context, v PrimitiveType) (T, error)
 	VisitOptional(ctx context.Context, v OptionalType) (T, error)
@@ -169,6 +347,62 @@ func (u *TypeDefinitionWithT[T]) Accept(ctx context.Context, v TypeDefinitionVis
 		}
 		return v.VisitUnion(ctx, *u.union)
 	}
+}
+
+func (u *TypeDefinitionWithT[T]) AcceptFuncs(aliasFunc func(AliasDefinition) (T, error), enumFunc func(EnumDefinition) (T, error), objectFunc func(ObjectDefinition) (T, error), unionFunc func(UnionDefinition) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "alias":
+		if u.alias == nil {
+			return result, fmt.Errorf("field \"alias\" is required")
+		}
+		return aliasFunc(*u.alias)
+	case "enum":
+		if u.enum == nil {
+			return result, fmt.Errorf("field \"enum\" is required")
+		}
+		return enumFunc(*u.enum)
+	case "object":
+		if u.object == nil {
+			return result, fmt.Errorf("field \"object\" is required")
+		}
+		return objectFunc(*u.object)
+	case "union":
+		if u.union == nil {
+			return result, fmt.Errorf("field \"union\" is required")
+		}
+		return unionFunc(*u.union)
+	}
+}
+
+func (u *TypeDefinitionWithT[T]) AliasNoopSuccess(AliasDefinition) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeDefinitionWithT[T]) EnumNoopSuccess(EnumDefinition) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeDefinitionWithT[T]) ObjectNoopSuccess(ObjectDefinition) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeDefinitionWithT[T]) UnionNoopSuccess(UnionDefinition) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *TypeDefinitionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
 }
 
 type TypeDefinitionVisitorWithT[T any] interface {

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -93,7 +93,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			goUnionGenericsFile.Comment("//go:build go1.18")
 			for _, union := range pkg.Unions {
 				writeUnionType(unionFile.Group, union, cfg.GenerateFuncsVisitor)
-				writeUnionTypeWithGenerics(goUnionGenericsFile.Group, union)
+				writeUnionTypeWithGenerics(goUnionGenericsFile.Group, union, cfg.GenerateFuncsVisitor)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "unions.conjure.go"), unionFile))
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "unions_generics.conjure.go"), goUnionGenericsFile))

--- a/conjure/unionwriter_test.go
+++ b/conjure/unionwriter_test.go
@@ -35,6 +35,18 @@ var testUnionType = &types.UnionType{
 	},
 }
 
+var testUnionTypeWithOptional = &types.UnionType{
+	Name: "MyUnionWithOptional",
+	Fields: []*types.Field{
+		{
+			Name: "stringVal", Type: types.String{},
+		},
+		{
+			Name: "optionalVal", Type: &types.Optional{Item: types.String{}},
+		},
+	},
+}
+
 func TestUnionWriter_unionVisitorInterfaceT(t *testing.T) {
 	f := jen.NewFile("testpkg")
 	unionVisitorWithT(f.Group, testUnionType)
@@ -96,4 +108,118 @@ func (u *MyUnionWithT[T]) Accept(ctx context.Context, v MyUnionVisitorWithT[T]) 
 	}
 }
 `, buf.String())
+}
+
+func TestUnionWriter_unionTypeWithTAcceptFuncs(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	unionTypeWithTAcceptFuncs(f.Group, testUnionType)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	assert.Equal(t, `package testpkg
+
+import "fmt"
+
+func (u *MyUnionWithT[T]) AcceptFuncs(stringValFunc func(string) (T, error), boolValFunc func(bool) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "stringVal":
+		if u.stringVal == nil {
+			return result, fmt.Errorf("field \"stringVal\" is required")
+		}
+		return stringValFunc(*u.stringVal)
+	case "boolVal":
+		if u.boolVal == nil {
+			return result, fmt.Errorf("field \"boolVal\" is required")
+		}
+		return boolValFunc(*u.boolVal)
+	}
+}
+func (u *MyUnionWithT[T]) StringValNoopSuccess(string) (T, error) {
+	var result T
+	return result, nil
+}
+func (u *MyUnionWithT[T]) BoolValNoopSuccess(bool) (T, error) {
+	var result T
+	return result, nil
+}
+func (u *MyUnionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+`, buf.String())
+}
+
+func TestUnionWriter_unionTypeWithTAcceptFuncs_withOptional(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	unionTypeWithTAcceptFuncs(f.Group, testUnionTypeWithOptional)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	assert.Equal(t, `package testpkg
+
+import "fmt"
+
+func (u *MyUnionWithOptionalWithT[T]) AcceptFuncs(stringValFunc func(string) (T, error), optionalValFunc func(*string) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "stringVal":
+		if u.stringVal == nil {
+			return result, fmt.Errorf("field \"stringVal\" is required")
+		}
+		return stringValFunc(*u.stringVal)
+	case "optionalVal":
+		var optionalVal *string
+		if u.optionalVal != nil {
+			optionalVal = *u.optionalVal
+		}
+		return optionalValFunc(optionalVal)
+	}
+}
+func (u *MyUnionWithOptionalWithT[T]) StringValNoopSuccess(string) (T, error) {
+	var result T
+	return result, nil
+}
+func (u *MyUnionWithOptionalWithT[T]) OptionalValNoopSuccess(*string) (T, error) {
+	var result T
+	return result, nil
+}
+func (u *MyUnionWithOptionalWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+`, buf.String())
+}
+
+func TestUnionWriter_writeUnionTypeWithGenerics_withAcceptFuncs(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	writeUnionTypeWithGenerics(f.Group, testUnionType, true)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	// Should contain AcceptFuncs
+	assert.Contains(t, buf.String(), "AcceptFuncs")
+	assert.Contains(t, buf.String(), "StringValNoopSuccess")
+	assert.Contains(t, buf.String(), "ErrorOnUnknown")
+}
+
+func TestUnionWriter_writeUnionTypeWithGenerics_withoutAcceptFuncs(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	writeUnionTypeWithGenerics(f.Group, testUnionType, false)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	// Should NOT contain AcceptFuncs
+	assert.NotContains(t, buf.String(), "AcceptFuncs")
+	assert.NotContains(t, buf.String(), "StringValNoopSuccess")
+	assert.NotContains(t, buf.String(), "ErrorOnUnknown")
+	// Should still contain Accept and visitor interface
+	assert.Contains(t, buf.String(), "Accept(ctx context.Context")
+	assert.Contains(t, buf.String(), "MyUnionVisitorWithT[T any]")
 }

--- a/cycles/testdata/cycle-within-pkg/conjure/com/palantir/foo/unions_generics.conjure.go
+++ b/cycles/testdata/cycle-within-pkg/conjure/com/palantir/foo/unions_generics.conjure.go
@@ -39,6 +39,52 @@ func (u *Type3WithT[T]) Accept(ctx context.Context, v Type3VisitorWithT[T]) (T, 
 	}
 }
 
+func (u *Type3WithT[T]) AcceptFuncs(field1Func func(Type2) (T, error), field2Func func(Type4) (T, error), field3Func func(bar.Type3) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "field1":
+		if u.field1 == nil {
+			return result, fmt.Errorf("field \"field1\" is required")
+		}
+		return field1Func(*u.field1)
+	case "field2":
+		if u.field2 == nil {
+			return result, fmt.Errorf("field \"field2\" is required")
+		}
+		return field2Func(*u.field2)
+	case "field3":
+		if u.field3 == nil {
+			return result, fmt.Errorf("field \"field3\" is required")
+		}
+		return field3Func(*u.field3)
+	}
+}
+
+func (u *Type3WithT[T]) Field1NoopSuccess(Type2) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field2NoopSuccess(Type4) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field3NoopSuccess(bar.Type3) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type Type3VisitorWithT[T any] interface {
 	VisitField1(ctx context.Context, v Type2) (T, error)
 	VisitField2(ctx context.Context, v Type4) (T, error)

--- a/cycles/testdata/no-cycles/conjure/com/palantir/foo/unions_generics.conjure.go
+++ b/cycles/testdata/no-cycles/conjure/com/palantir/foo/unions_generics.conjure.go
@@ -39,6 +39,52 @@ func (u *Type3WithT[T]) Accept(ctx context.Context, v Type3VisitorWithT[T]) (T, 
 	}
 }
 
+func (u *Type3WithT[T]) AcceptFuncs(field1Func func(Type2) (T, error), field2Func func(Type4) (T, error), field3Func func(bar.Type3) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "field1":
+		if u.field1 == nil {
+			return result, fmt.Errorf("field \"field1\" is required")
+		}
+		return field1Func(*u.field1)
+	case "field2":
+		if u.field2 == nil {
+			return result, fmt.Errorf("field \"field2\" is required")
+		}
+		return field2Func(*u.field2)
+	case "field3":
+		if u.field3 == nil {
+			return result, fmt.Errorf("field \"field3\" is required")
+		}
+		return field3Func(*u.field3)
+	}
+}
+
+func (u *Type3WithT[T]) Field1NoopSuccess(Type2) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field2NoopSuccess(Type4) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field3NoopSuccess(bar.Type3) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type Type3VisitorWithT[T any] interface {
 	VisitField1(ctx context.Context, v Type2) (T, error)
 	VisitField2(ctx context.Context, v Type4) (T, error)

--- a/cycles/testdata/pkg-cycle-disconnected/conjure/com/palantir/foo1/unions_generics.conjure.go
+++ b/cycles/testdata/pkg-cycle-disconnected/conjure/com/palantir/foo1/unions_generics.conjure.go
@@ -29,6 +29,32 @@ func (u *Type3WithT[T]) Accept(ctx context.Context, v Type3VisitorWithT[T]) (T, 
 	}
 }
 
+func (u *Type3WithT[T]) AcceptFuncs(field3Func func(bar.Type1) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "field3":
+		if u.field3 == nil {
+			return result, fmt.Errorf("field \"field3\" is required")
+		}
+		return field3Func(*u.field3)
+	}
+}
+
+func (u *Type3WithT[T]) Field3NoopSuccess(bar.Type1) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type Type3VisitorWithT[T any] interface {
 	VisitField3(ctx context.Context, v bar.Type1) (T, error)
 	VisitUnknown(ctx context.Context, typ string) (T, error)

--- a/cycles/testdata/pkg-cycle/conjure/com/palantir/foo1/unions_generics.conjure.go
+++ b/cycles/testdata/pkg-cycle/conjure/com/palantir/foo1/unions_generics.conjure.go
@@ -40,6 +40,52 @@ func (u *Type3WithT[T]) Accept(ctx context.Context, v Type3VisitorWithT[T]) (T, 
 	}
 }
 
+func (u *Type3WithT[T]) AcceptFuncs(field1Func func(foo.Type2) (T, error), field2Func func(foo.Type4) (T, error), field3Func func(bar.Type1) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "field1":
+		if u.field1 == nil {
+			return result, fmt.Errorf("field \"field1\" is required")
+		}
+		return field1Func(*u.field1)
+	case "field2":
+		if u.field2 == nil {
+			return result, fmt.Errorf("field \"field2\" is required")
+		}
+		return field2Func(*u.field2)
+	case "field3":
+		if u.field3 == nil {
+			return result, fmt.Errorf("field \"field3\" is required")
+		}
+		return field3Func(*u.field3)
+	}
+}
+
+func (u *Type3WithT[T]) Field1NoopSuccess(foo.Type2) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field2NoopSuccess(foo.Type4) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) Field3NoopSuccess(bar.Type1) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *Type3WithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type Type3VisitorWithT[T any] interface {
 	VisitField1(ctx context.Context, v foo.Type2) (T, error)
 	VisitField2(ctx context.Context, v foo.Type4) (T, error)

--- a/cycles/testdata/type-cycle/conjure/com/palantir/bar_foo/unions_generics.conjure.go
+++ b/cycles/testdata/type-cycle/conjure/com/palantir/bar_foo/unions_generics.conjure.go
@@ -32,6 +32,42 @@ func (u *FooType3WithT[T]) Accept(ctx context.Context, v FooType3VisitorWithT[T]
 	}
 }
 
+func (u *FooType3WithT[T]) AcceptFuncs(field1Func func(Type2) (T, error), field3Func func(Type1) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "field1":
+		if u.field1 == nil {
+			return result, fmt.Errorf("field \"field1\" is required")
+		}
+		return field1Func(*u.field1)
+	case "field3":
+		if u.field3 == nil {
+			return result, fmt.Errorf("field \"field3\" is required")
+		}
+		return field3Func(*u.field3)
+	}
+}
+
+func (u *FooType3WithT[T]) Field1NoopSuccess(Type2) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *FooType3WithT[T]) Field3NoopSuccess(Type1) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *FooType3WithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type FooType3VisitorWithT[T any] interface {
 	VisitField1(ctx context.Context, v Type2) (T, error)
 	VisitField3(ctx context.Context, v Type1) (T, error)

--- a/integration_test/testgenerated/cli/api/unions_generics.conjure.go
+++ b/integration_test/testgenerated/cli/api/unions_generics.conjure.go
@@ -32,6 +32,42 @@ func (u *CustomUnionWithT[T]) Accept(ctx context.Context, v CustomUnionVisitorWi
 	}
 }
 
+func (u *CustomUnionWithT[T]) AcceptFuncs(asStringFunc func(string) (T, error), asIntegerFunc func(int) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "asString":
+		if u.asString == nil {
+			return result, fmt.Errorf("field \"asString\" is required")
+		}
+		return asStringFunc(*u.asString)
+	case "asInteger":
+		if u.asInteger == nil {
+			return result, fmt.Errorf("field \"asInteger\" is required")
+		}
+		return asIntegerFunc(*u.asInteger)
+	}
+}
+
+func (u *CustomUnionWithT[T]) AsStringNoopSuccess(string) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *CustomUnionWithT[T]) AsIntegerNoopSuccess(int) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *CustomUnionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type CustomUnionVisitorWithT[T any] interface {
 	VisitAsString(ctx context.Context, v string) (T, error)
 	VisitAsInteger(ctx context.Context, v int) (T, error)

--- a/integration_test/testgenerated/imports/pkg3/api/unions_generics.conjure.go
+++ b/integration_test/testgenerated/imports/pkg3/api/unions_generics.conjure.go
@@ -47,6 +47,62 @@ func (u *UnionWithT[T]) Accept(ctx context.Context, v UnionVisitorWithT[T]) (T, 
 	}
 }
 
+func (u *UnionWithT[T]) AcceptFuncs(oneFunc func(api.Struct1) (T, error), twoFunc func(api1.Struct2) (T, error), threeFunc func(v2.ObjectInPackageEndingInVersion) (T, error), fourFunc func(v21.DifferentPackageEndingInVersion) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "one":
+		if u.one == nil {
+			return result, fmt.Errorf("field \"one\" is required")
+		}
+		return oneFunc(*u.one)
+	case "two":
+		if u.two == nil {
+			return result, fmt.Errorf("field \"two\" is required")
+		}
+		return twoFunc(*u.two)
+	case "three":
+		if u.three == nil {
+			return result, fmt.Errorf("field \"three\" is required")
+		}
+		return threeFunc(*u.three)
+	case "four":
+		if u.four == nil {
+			return result, fmt.Errorf("field \"four\" is required")
+		}
+		return fourFunc(*u.four)
+	}
+}
+
+func (u *UnionWithT[T]) OneNoopSuccess(api.Struct1) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *UnionWithT[T]) TwoNoopSuccess(api1.Struct2) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *UnionWithT[T]) ThreeNoopSuccess(v2.ObjectInPackageEndingInVersion) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *UnionWithT[T]) FourNoopSuccess(v21.DifferentPackageEndingInVersion) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *UnionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type UnionVisitorWithT[T any] interface {
 	VisitOne(ctx context.Context, v api.Struct1) (T, error)
 	VisitTwo(ctx context.Context, v api1.Struct2) (T, error)

--- a/integration_test/testgenerated/objects/api/unions_generics.conjure.go
+++ b/integration_test/testgenerated/objects/api/unions_generics.conjure.go
@@ -38,6 +38,53 @@ func (u *ExampleUnionWithT[T]) Accept(ctx context.Context, v ExampleUnionVisitor
 	}
 }
 
+func (u *ExampleUnionWithT[T]) AcceptFuncs(strFunc func(string) (T, error), strOptionalFunc func(*string) (T, error), otherFunc func(int) (T, error), unknownFunc func(string) (T, error)) (T, error) {
+	var result T
+	switch u.typ {
+	default:
+		if u.typ == "" {
+			return result, fmt.Errorf("invalid value in union type")
+		}
+		return unknownFunc(u.typ)
+	case "str":
+		if u.str == nil {
+			return result, fmt.Errorf("field \"str\" is required")
+		}
+		return strFunc(*u.str)
+	case "strOptional":
+		var strOptional *string
+		if u.strOptional != nil {
+			strOptional = *u.strOptional
+		}
+		return strOptionalFunc(strOptional)
+	case "other":
+		if u.other == nil {
+			return result, fmt.Errorf("field \"other\" is required")
+		}
+		return otherFunc(*u.other)
+	}
+}
+
+func (u *ExampleUnionWithT[T]) StrNoopSuccess(string) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ExampleUnionWithT[T]) StrOptionalNoopSuccess(*string) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ExampleUnionWithT[T]) OtherNoopSuccess(int) (T, error) {
+	var result T
+	return result, nil
+}
+
+func (u *ExampleUnionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
+	var result T
+	return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
+}
+
 type ExampleUnionVisitorWithT[T any] interface {
 	VisitStr(ctx context.Context, v string) (T, error)
 	VisitStrOptional(ctx context.Context, v *string) (T, error)


### PR DESCRIPTION
This PR implements `AcceptFuncs` method generation for paremeterised/generic unions (`ThingWithT[T]`), bringing feature parity with non-parameterised/generic unions. The `AcceptFuncs` method provides an alternative to the visitor pattern that uses function parameters instead of interface implementations.

- **Added `AcceptFuncs` method generation** for generic unions that accepts function parameters returning `(T, error)`
- **Added helper methods** (`*NoopSuccess`, `ErrorOnUnknown`) for generic unions returning `(T, error)`
- **Added conditional generation** based on `cfg.GenerateFuncsVisitor` flag (matches non-generic behavior)
- **Comprehensive test coverage** including optional field handling and configuration scenarios

- **Return type**: `(T, error)` instead of just `error`

For a union with `string` and `int` fields:
```go
func (u *MyUnionWithT[T]) AcceptFuncs(
    strFunc func(string) (T, error),
    intFunc func(int) (T, error),
    unknownFunc func(string) (T, error)
) (T, error) {
    var result T
    switch u.typ {
    case "str":
        if u.str == nil {
            return result, fmt.Errorf("field \"str\" is required")
        }
        return strFunc(*u.str)
    // ... other cases
    }
}

func (u *MyUnionWithT[T]) StrNoopSuccess(string) (T, error) {
    var result T
    return result, nil
}

func (u *MyUnionWithT[T]) ErrorOnUnknown(typeName string) (T, error) {
    var result T
    return result, fmt.Errorf("invalid value in union type. Type name: %s", typeName)
}
```

- **Enabled**: When `GenerateFuncsVisitor: true` in conjure configuration
- **Disabled**: When `GenerateFuncsVisitor: false` (default behavior unchanged)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/725)
<!-- Reviewable:end -->
