### PR TITLE
Parse safety for External type from conjure IR

### DIFF
--- a/conjure-api/conjure-api-4.35.0.conjure.json
+++ b/conjure-api/conjure-api-4.35.0.conjure.json
@@ -672,6 +672,21 @@
           }
         },
         "docs" : "Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.\n"
+      }, {
+        "fieldName" : "safety",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "LogSafety",
+                "package" : "com.palantir.conjure.spec"
+              }
+            }
+          }
+        },
+        "docs" : "The safety level of the external type."
       } ]
     }
   }, {

--- a/conjure-api/conjure/spec/structs.conjure.go
+++ b/conjure-api/conjure/spec/structs.conjure.go
@@ -368,6 +368,8 @@ type ExternalReference struct {
 	ExternalReference TypeName `conjure-docs:"An identifier for a non-Conjure type which is already defined in a different language (e.g. Java)." json:"externalReference"`
 	// Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
 	Fallback Type `conjure-docs:"Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable." json:"fallback"`
+	// The safety level of the external type.
+	Safety *LogSafety `conjure-docs:"The safety level of the external type." json:"safety,omitempty"`
 }
 
 func (o ExternalReference) MarshalYAML() (interface{}, error) {

--- a/conjure/objectwriter_test.go
+++ b/conjure/objectwriter_test.go
@@ -551,6 +551,146 @@ func (o *DocumentedMixedObject) UnmarshalYAML(unmarshal func(interface{}) error)
 }
 `,
 		},
+		{
+			name: "Object with External type with safety",
+			in: &types.ObjectType{
+				Name: "MyObject",
+				Fields: []*types.Field{
+					{
+						Name: "externalField",
+						Type: &types.External{
+							Spec: spec.TypeName{
+								Name:    "com/palantir/apollo/deployment:ApolloEnvironmentId",
+								Package: "github.com/palantir/apollo-deployment-api",
+							},
+							Fallback: types.String{},
+						},
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	deployment "github.com/palantir/apollo-deployment-api.com/palantir/apollo/deployment"
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+type MyObject struct {
+	ExternalField deployment.ApolloEnvironmentId ` + "`json:\"externalField\"`" + `
+}
+
+func (o MyObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *MyObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with External type with SAFE safety",
+			in: &types.ObjectType{
+				Name: "MyObject",
+				Fields: []*types.Field{
+					{
+						Name: "safeExternalField",
+						Type: types.NewExternalWithSafety(
+							spec.TypeName{
+								Name:    "com/palantir/apollo/deployment:ApolloEnvironmentId",
+								Package: "github.com/palantir/apollo-deployment-api",
+							},
+							types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }(),
+						),
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	deployment "github.com/palantir/apollo-deployment-api.com/palantir/apollo/deployment"
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@Safe
+type MyObject struct {
+	SafeExternalField deployment.ApolloEnvironmentId ` + "`json:\"safeExternalField\" safelogging:\"@Safe\"`" + `
+}
+
+func (o MyObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *MyObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
+		{
+			name: "Object with External type with UNSAFE safety overridden by field SAFE safety",
+			in: &types.ObjectType{
+				Name: "MyObject",
+				Fields: []*types.Field{
+					{
+						Name: "overriddenField",
+						Type: types.NewExternalWithSafety(
+							spec.TypeName{
+								Name:    "com/palantir/apollo/deployment:ApolloEnvironmentId",
+								Package: "github.com/palantir/apollo-deployment-api",
+							},
+							types.String{},
+							func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_UNSAFE); return &s }(),
+						),
+						Safety: func() *spec.LogSafety { s := spec.New_LogSafety(spec.LogSafety_SAFE); return &s }(),
+					},
+				},
+			},
+			Out: `package testpkg
+
+import (
+	deployment "github.com/palantir/apollo-deployment-api.com/palantir/apollo/deployment"
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+// safelogging:@Safe
+type MyObject struct {
+	OverriddenField deployment.ApolloEnvironmentId ` + "`json:\"overriddenField\" safelogging:\"@Safe\"`" + `
+}
+
+func (o MyObject) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *MyObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := jen.NewFile("testpkg")

--- a/conjure/types/conjure_definition.go
+++ b/conjure/types/conjure_definition.go
@@ -269,7 +269,11 @@ func (t *namedTypes) GetBySpec(typ spec.Type) (out Type) {
 			return nil
 		},
 		func(external spec.ExternalReference) error {
-			out = &External{Spec: external.ExternalReference, Fallback: t.GetBySpec(external.Fallback)}
+			out = &External{
+				Spec:     external.ExternalReference,
+				Fallback: t.GetBySpec(external.Fallback),
+				safety:   external.Safety,
+			}
 			return nil
 		}, typ.ErrorOnUnknown); err != nil {
 		return nil

--- a/conjure/types/types.go
+++ b/conjure/types/types.go
@@ -318,6 +318,7 @@ func (*UnionType) ContainsStrictFields() bool { return true }
 type External struct {
 	Spec     spec.TypeName
 	Fallback Type
+	safety   *spec.LogSafety
 	base
 }
 
@@ -342,6 +343,22 @@ func (t *External) String() string {
 
 func (t *External) ExternalHasGoType() bool {
 	return strings.Contains(t.Spec.Name, ":")
+}
+
+func (t *External) Safety() spec.LogSafety {
+	if t.safety != nil {
+		return *t.safety
+	}
+	return t.Fallback.Safety()
+}
+
+// NewExternalWithSafety creates an External type with safety annotation
+func NewExternalWithSafety(spec spec.TypeName, fallback Type, safety *spec.LogSafety) *External {
+	return &External{
+		Spec:     spec,
+		Fallback: fallback,
+		safety:   safety,
+	}
 }
 
 // Public member types


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/conjure-go/pull/714 generates safelogging tags, but there is a missing case where a struct field references an external type, in which case it should use the external type's safety if defined.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Parse safety for External type from conjure IR
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/745)
<!-- Reviewable:end -->
