### PR TITLE
feature: filter conjure extensions to only `recommended-product-dependencies`

### DIFF
--- a/conjure-api/conjure-api-4.35.0.conjure.json
+++ b/conjure-api/conjure-api-4.35.0.conjure.json
@@ -1325,6 +1325,7 @@
   } ],
   "services" : [ ],
   "extensions" : {
+    "not-recommended-product-dependencies" : [ ],
     "recommended-product-dependencies" : [ ]
   }
 }

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -126,10 +126,14 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "servers.conjure.go"), serverFile))
 		}
-		if len(def.Extensions) > 0 {
+
+		const recommendedProductDependencies = "recommended-product-dependencies"
+		if v, ok := def.Extensions[recommendedProductDependencies]; ok {
 			const extensions = "extensions.conjure.json"
 
-			extensionsContent, err := safejson.MarshalIndent(def.Extensions, "", "\t")
+			extensionsContent, err := safejson.MarshalIndent(map[string]any{
+				recommendedProductDependencies: v,
+			}, "", "\t")
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to marshal the conjure IR `extensions` field")
 			}


### PR DESCRIPTION
## Before this PR
A lot of noise was being created by `extension` keys that were not being consumed.

## After this PR
We now filter out all `extension` keys except for those that we expect to consume.

==COMMIT_MSG==
filter conjure extensions to only `recommended-product-dependencies`
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/747)
<!-- Reviewable:end -->
