### PR TITLE
feature: Implement server-request-context endpoint tag

### DIFF
--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -16,6 +16,7 @@ package conjure
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/dave/jennifer/jen"
@@ -26,6 +27,8 @@ import (
 )
 
 const (
+	endpointTagServerRequestContext = "server-request-context"
+
 	implName = "impl"
 
 	// Handler
@@ -436,6 +439,9 @@ func astForDecodeHTTPParamInternal(methodBody *jen.Group, argName string, argTyp
 func astForHandlerExecImplAndReturn(g *jen.Group, serviceName string, endpointDef *types.EndpointDefinition) {
 	callFunc := jen.Id(handlerReceiverName(serviceName)).Dot(implName).Dot(strings.Title(endpointDef.EndpointName)).CallFunc(func(g *jen.Group) {
 		g.Id(reqName).Dot("Context").Call()
+		if slices.Contains(endpointDef.Tags, endpointTagServerRequestContext) {
+			g.Id(reqName)
+		}
 		if endpointDef.HeaderAuth {
 			g.Add(snip.BearerTokenToken()).Call(jen.Id(authHeaderVar))
 		} else if endpointDef.CookieAuth != nil {

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -17,6 +17,7 @@ package conjure
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/dave/jennifer/jen"
@@ -102,6 +103,11 @@ func astForServiceInterface(serviceDef *types.ServiceDefinition, withAuth, isSer
 
 func astForEndpointArgsFunc(args *jen.Group, endpointDef *types.EndpointDefinition, withAuth, isServer bool) {
 	args.Id(ctxName).Add(snip.Context())
+	if isServer {
+		if slices.Contains(endpointDef.Tags, endpointTagServerRequestContext) {
+			args.Id("req").Op("*").Add(snip.HTTPRequest())
+		}
+	}
 	if !withAuth {
 		if endpointDef.HeaderAuth {
 			args.Id(authHeaderVar).Add(types.Bearertoken{}.Code())

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -22,7 +22,7 @@ import (
 )
 
 type TestService interface {
-	Echo(ctx context.Context, cookieToken bearertoken.Token) error
+	Echo(ctx context.Context, req *http.Request, cookieToken bearertoken.Token) error
 	EchoStrings(ctx context.Context, bodyArg []string) ([]string, error)
 	EchoCustomObject(ctx context.Context, bodyArg *CustomObject) (*CustomObject, error)
 	EchoOptionalAlias(ctx context.Context, bodyArg OptionalIntegerAlias) (OptionalIntegerAlias, error)
@@ -161,7 +161,7 @@ func (t *testServiceHandler) HandleEcho(rw http.ResponseWriter, req *http.Reques
 		return errors.WrapWithPermissionDenied(err)
 	}
 	cookieToken := bearertoken.Token(authCookie.Value)
-	if err := t.impl.Echo(req.Context(), cookieToken); err != nil {
+	if err := t.impl.Echo(req.Context(), req, cookieToken); err != nil {
 		return err
 	}
 	rw.WriteHeader(http.StatusNoContent)

--- a/integration_test/testgenerated/server/server-service.yml
+++ b/integration_test/testgenerated/server/server-service.yml
@@ -42,6 +42,8 @@ services:
       echo:
         http: GET /echo
         auth: "cookie:PALANTIR_TOKEN"
+        tags:
+          - server-request-context
       echoStrings:
         http: POST /echo
         args:

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -290,7 +290,7 @@ func (t testServerImpl) PostSafeParams(ctx context.Context, authHeader bearertok
 	return nil
 }
 
-func (t testServerImpl) Echo(ctx context.Context, cookieToken bearertoken.Token) error {
+func (t testServerImpl) Echo(ctx context.Context, req *http.Request, cookieToken bearertoken.Token) error {
 	panic("implement me")
 }
 


### PR DESCRIPTION
This is a feature in conjure-java: https://github.com/palantir/conjure-java?tab=readme-ov-file#endpoint-tags

In go, we'll add the `*http.Request` as an argument in the server impl interfaces and call sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/820)
<!-- Reviewable:end -->
