### PR TITLE
Feature: Allow generated code to use WGS/CGR V2 or V3 module versions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,21 +24,21 @@ import (
 )
 
 const (
-	outputDirFlagName   = "output"
-	serverFlagName      = "server"
+	outputDirFlagName    = "output"
+	serverFlagName       = "server"
 	funcsVisitorFlagName = "funcs-visitor"
-	cgrVersionFlagName  = "cgr-version"
-	wgsVersionFlagName  = "wgs-version"
+	cgrVersionFlagName   = "cgr-version"
+	wgsVersionFlagName   = "wgs-version"
 )
 
 var (
-	version             = "unspecified"
-	debug               bool
-	outputDirFlagVar    string
-	serverFlagVar       bool
-	funcsVisitorFlagVar bool
-	cgrVersionFlagVar   int
-	wgsVersionFlagVar   int
+	version                 = "unspecified"
+	debug                   bool
+	outputDirFlagVar        string
+	serverFlagVar           bool
+	funcsVisitorFlagVar     bool
+	cgrModuleVersionFlagVar int
+	wgsModuleVersionFlagVar int
 )
 
 var rootCmd = &cobra.Command{
@@ -59,8 +59,8 @@ func init() {
 	rootCmd.Flags().StringVar(&outputDirFlagVar, outputDirFlagName, ".", "base directory into which generated Conjure is written")
 	rootCmd.Flags().BoolVar(&serverFlagVar, serverFlagName, false, "enable witchcraft-go server generation")
 	rootCmd.Flags().BoolVar(&funcsVisitorFlagVar, funcsVisitorFlagName, false, "enable witchcraft-go funcs visitor generation")
-	rootCmd.Flags().IntVar(&cgrVersionFlagVar, cgrVersionFlagName, 2, "version of conjure-go-runtime to use in generated imports (2 or 3)")
-	rootCmd.Flags().IntVar(&wgsVersionFlagVar, wgsVersionFlagName, 2, "version of witchcraft-go-server to use in generated imports (2 or 3)")
+	rootCmd.Flags().IntVar(&cgrModuleVersionFlagVar, cgrVersionFlagName, 2, "conjure-go-runtime module version to use in generated code (2 or 3)")
+	rootCmd.Flags().IntVar(&wgsModuleVersionFlagVar, wgsVersionFlagName, 2, "witchcraft-go-server module version to use in generated code (2 or 3)")
 }
 
 func Generate(irFile, outDir string) error {
@@ -75,8 +75,8 @@ func Generate(irFile, outDir string) error {
 		GenerateFuncsVisitor: funcsVisitorFlagVar,
 		GenerateServer:       serverFlagVar,
 		OutputDir:            outDir,
-		CGRVersion:           cgrVersionFlagVar,
-		WGSVersion:           wgsVersionFlagVar,
+		CGRModuleVersion:     cgrModuleVersionFlagVar,
+		WGSModuleVersion:     wgsModuleVersionFlagVar,
 	}
 	if err := conjure.Generate(conjureDefinition, output); err != nil {
 		return errors.Wrapf(err, "failed to generate Conjure")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,9 +24,11 @@ import (
 )
 
 const (
-	outputDirFlagName    = "output"
-	serverFlagName       = "server"
+	outputDirFlagName   = "output"
+	serverFlagName      = "server"
 	funcsVisitorFlagName = "funcs-visitor"
+	cgrVersionFlagName  = "cgr-version"
+	wgsVersionFlagName  = "wgs-version"
 )
 
 var (
@@ -35,6 +37,8 @@ var (
 	outputDirFlagVar    string
 	serverFlagVar       bool
 	funcsVisitorFlagVar bool
+	cgrVersionFlagVar   int
+	wgsVersionFlagVar   int
 )
 
 var rootCmd = &cobra.Command{
@@ -55,6 +59,8 @@ func init() {
 	rootCmd.Flags().StringVar(&outputDirFlagVar, outputDirFlagName, ".", "base directory into which generated Conjure is written")
 	rootCmd.Flags().BoolVar(&serverFlagVar, serverFlagName, false, "enable witchcraft-go server generation")
 	rootCmd.Flags().BoolVar(&funcsVisitorFlagVar, funcsVisitorFlagName, false, "enable witchcraft-go funcs visitor generation")
+	rootCmd.Flags().IntVar(&cgrVersionFlagVar, cgrVersionFlagName, 2, "version of conjure-go-runtime to use in generated imports (2 or 3)")
+	rootCmd.Flags().IntVar(&wgsVersionFlagVar, wgsVersionFlagName, 2, "version of witchcraft-go-server to use in generated imports (2 or 3)")
 }
 
 func Generate(irFile, outDir string) error {
@@ -69,6 +75,8 @@ func Generate(irFile, outDir string) error {
 		GenerateFuncsVisitor: funcsVisitorFlagVar,
 		GenerateServer:       serverFlagVar,
 		OutputDir:            outDir,
+		CGRVersion:           cgrVersionFlagVar,
+		WGSVersion:           wgsVersionFlagVar,
 	}
 	if err := conjure.Generate(conjureDefinition, output); err != nil {
 		return errors.Wrapf(err, "failed to generate Conjure")

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -44,6 +44,10 @@ func Generate(conjureDefinition spec.ConjureDefinition, outputConfiguration Outp
 }
 
 func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputConfiguration) ([]*OutputFile, error) {
+	// Set the runtime versions before generating any code
+	snip.SetCGRVersion(cfg.CGRVersion)
+	snip.SetWGSVersion(cfg.WGSVersion)
+
 	def, err := types.NewConjureDefinition(cfg.OutputDir, conjureDefinition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid configuration")
@@ -58,7 +62,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			return nil, errors.Wrapf(err, "failed to determine import path for error registry package")
 		}
 		errorRegistryJenFile := jen.NewFilePathName(errorRegistryImportPath, path.Base(errorRegistryImportPath))
-		errorRegistryJenFile.ImportNames(snip.DefaultImportsToPackageNames)
+		errorRegistryJenFile.ImportNames(snip.ImportsToPackageNames())
 		writeErrorRegistryFile(errorRegistryJenFile.Group)
 		errorRegistryOutputDir, err := types.GetOutputDirectoryForGoPackage(cfg.OutputDir, errorRegistryImportPath)
 		if err != nil {
@@ -180,7 +184,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 
 func newJenFile(pkg types.ConjurePackage, def *types.ConjureDefinition, errorRegistryImportPath string) *jen.File {
 	f := jen.NewFilePathName(pkg.ImportPath, pkg.PackageName)
-	f.ImportNames(snip.DefaultImportsToPackageNames)
+	f.ImportNames(snip.ImportsToPackageNames())
 	for _, conjurePackage := range def.Packages {
 		if packageSuffixRequiresAlias(conjurePackage.ImportPath) {
 			f.ImportAlias(conjurePackage.ImportPath, conjurePackage.PackageName)

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -45,12 +45,8 @@ func Generate(conjureDefinition spec.ConjureDefinition, outputConfiguration Outp
 
 func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputConfiguration) ([]*OutputFile, error) {
 	// Set the runtime versions before generating any code
-	if err := snip.SetCGRModuleVersion(cfg.CGRModuleVersion); err != nil {
-		return nil, err
-	}
-	if err := snip.SetWGSModuleVersion(cfg.WGSModuleVersion); err != nil {
-		return nil, err
-	}
+	snip.SetCGRModuleVersion(cfg.CGRModuleVersion)
+	snip.SetWGSModuleVersion(cfg.WGSModuleVersion)
 
 	def, err := types.NewConjureDefinition(cfg.OutputDir, conjureDefinition)
 	if err != nil {

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -45,8 +45,12 @@ func Generate(conjureDefinition spec.ConjureDefinition, outputConfiguration Outp
 
 func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputConfiguration) ([]*OutputFile, error) {
 	// Set the runtime versions before generating any code
-	snip.SetCGRVersion(cfg.CGRVersion)
-	snip.SetWGSVersion(cfg.WGSVersion)
+	if err := snip.SetCGRModuleVersion(cfg.CGRModuleVersion); err != nil {
+		return nil, err
+	}
+	if err := snip.SetWGSModuleVersion(cfg.WGSModuleVersion); err != nil {
+		return nil, err
+	}
 
 	def, err := types.NewConjureDefinition(cfg.OutputDir, conjureDefinition)
 	if err != nil {

--- a/conjure/output_configuration.go
+++ b/conjure/output_configuration.go
@@ -19,6 +19,6 @@ type OutputConfiguration struct {
 	GenerateServer       bool
 	GenerateCLI          bool
 	OutputDir            string
-	CGRVersion           int // conjure-go-runtime version (2 or 3), defaults to 2
-	WGSVersion           int // witchcraft-go-server version (2 or 3), defaults to 2
+	CGRModuleVersion     int
+	WGSModuleVersion     int
 }

--- a/conjure/output_configuration.go
+++ b/conjure/output_configuration.go
@@ -19,4 +19,6 @@ type OutputConfiguration struct {
 	GenerateServer       bool
 	GenerateCLI          bool
 	OutputDir            string
+	CGRVersion           int // conjure-go-runtime version (2 or 3), defaults to 2
+	WGSVersion           int // witchcraft-go-server version (2 or 3), defaults to 2
 }

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/dave/jennifer/jen"
+	werror "github.com/palantir/witchcraft-go-error"
 )
 
 const (
@@ -26,34 +27,42 @@ const (
 )
 
 var (
-	// cgrVersion controls which version of conjure-go-runtime to use in generated imports.
+	// cgrModuleVersion controls which conjure-go-runtime module version to use in generated code.
 	// Defaults to 2. Set via SetCGRVersion before generation.
-	cgrVersion = 2
-	// wgsVersion controls which version of witchcraft-go-server to use in generated imports.
+	cgrModuleVersion = 2
+	// wgsModuleVersion controls which witchcraft-go-server module version to use in generated code.
 	// Defaults to 2. Set via SetWGSVersion before generation.
-	wgsVersion = 2
+	wgsModuleVersion = 2
 )
 
-// SetCGRVersion sets the version of conjure-go-runtime to use in generated imports.
+// SetCGRModuleVersion sets the version of conjure-go-runtime to use in generated imports.
 // Valid values are 2 or 3.
-func SetCGRVersion(version int) {
-	cgrVersion = version
+func SetCGRModuleVersion(version int) error {
+	if version != 2 && version != 3 {
+		return werror.Error("conjure-go-runtime module version must be either 2 or 3", werror.SafeParam("moduleVersion", version))
+	}
+	cgrModuleVersion = version
+	return nil
 }
 
-// SetWGSVersion sets the version of witchcraft-go-server to use in generated imports.
+// SetWGSModuleVersion sets the version of witchcraft-go-server to use in generated imports.
 // Valid values are 2 or 3.
-func SetWGSVersion(version int) {
-	wgsVersion = version
+func SetWGSModuleVersion(version int) error {
+	if version != 2 && version != 3 {
+		return werror.Error("witchcraft-go-server module version must be either 2 or 3", werror.SafeParam("moduleVersion", version))
+	}
+	wgsModuleVersion = version
+	return nil
 }
 
 // cgr returns the conjure-go-runtime import path prefix for the configured version.
 func cgr() string {
-	return fmt.Sprintf("%sconjure-go-runtime/v%d/", pal, cgrVersion)
+	return fmt.Sprintf("%sconjure-go-runtime/v%d/", pal, cgrModuleVersion)
 }
 
 // wgs returns the witchcraft-go-server import path prefix for the configured version.
 func wgs() string {
-	return fmt.Sprintf("%switchcraft-go-server/v%d/", pal, wgsVersion)
+	return fmt.Sprintf("%switchcraft-go-server/v%d/", pal, wgsModuleVersion)
 }
 
 // ImportsToPackageNames returns a map of import paths to package names for use with jennifer.
@@ -128,8 +137,7 @@ var (
 	StrconvParseFloat   = jen.Qual("strconv", "ParseFloat").Clone
 )
 
-// Version-dependent imports for conjure-go-runtime.
-// These are functions rather than vars so they use the current runtimeVersion.
+// conjure-go-runtime imports (version-dependent)
 
 func CGRClientClient() *jen.Statement {
 	return jen.Qual(cgr()+"conjure-go-client/httpclient", "Client")
@@ -267,7 +275,39 @@ func CGRHTTPServerStatusCodeMapper() *jen.Statement {
 	return jen.Qual(cgr()+"conjure-go-server/httpserver", "StatusCodeMapper")
 }
 
-// Static imports that don't depend on runtime version.
+// witchcraft-go-server imports (version-dependent)
+
+func WresourceNew() *jen.Statement {
+	return jen.Qual(wgs()+"witchcraft/wresource", "New")
+}
+func WrouterPathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "PathParams")
+}
+func WrouterRouteParam() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "RouteParam")
+}
+func WrouterRouter() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "Router")
+}
+func WrouterForbiddenHeaderParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenHeaderParams")
+}
+func WrouterForbiddenPathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenPathParams")
+}
+func WrouterForbiddenQueryParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenQueryParams")
+}
+func WrouterSafeHeaderParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafeHeaderParams")
+}
+func WrouterSafePathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafePathParams")
+}
+func WrouterSafeQueryParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafeQueryParams")
+}
+
 var (
 	BinaryBinary                   = jen.Qual(pal+"pkg/binary", "Binary").Clone
 	BinaryNew                      = jen.Qual(pal+"pkg/binary", "New").Clone
@@ -314,37 +354,3 @@ var (
 
 	PflagsFlagset = jen.Qual("github.com/spf13/pflag", "FlagSet").Clone
 )
-
-// Version-dependent imports for witchcraft-go-server.
-// These are functions rather than vars so they use the current runtimeVersion.
-
-func WresourceNew() *jen.Statement {
-	return jen.Qual(wgs()+"witchcraft/wresource", "New")
-}
-func WrouterPathParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "PathParams")
-}
-func WrouterRouteParam() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "RouteParam")
-}
-func WrouterRouter() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "Router")
-}
-func WrouterForbiddenHeaderParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "ForbiddenHeaderParams")
-}
-func WrouterForbiddenPathParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "ForbiddenPathParams")
-}
-func WrouterForbiddenQueryParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "ForbiddenQueryParams")
-}
-func WrouterSafeHeaderParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "SafeHeaderParams")
-}
-func WrouterSafePathParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "SafePathParams")
-}
-func WrouterSafeQueryParams() *jen.Statement {
-	return jen.Qual(wgs()+"wrouter", "SafeQueryParams")
-}

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/dave/jennifer/jen"
-	werror "github.com/palantir/witchcraft-go-error"
 )
 
 const (
@@ -37,22 +36,20 @@ var (
 
 // SetCGRModuleVersion sets the version of conjure-go-runtime to use in generated imports.
 // Valid values are 2 or 3.
-func SetCGRModuleVersion(version int) error {
+func SetCGRModuleVersion(version int) {
 	if version != 2 && version != 3 {
-		return werror.Error("conjure-go-runtime module version must be either 2 or 3", werror.SafeParam("moduleVersion", version))
+		version = cgrModuleVersion
 	}
 	cgrModuleVersion = version
-	return nil
 }
 
 // SetWGSModuleVersion sets the version of witchcraft-go-server to use in generated imports.
 // Valid values are 2 or 3.
-func SetWGSModuleVersion(version int) error {
+func SetWGSModuleVersion(version int) {
 	if version != 2 && version != 3 {
-		return werror.Error("witchcraft-go-server module version must be either 2 or 3", werror.SafeParam("moduleVersion", version))
+		version = wgsModuleVersion
 	}
 	wgsModuleVersion = version
-	return nil
 }
 
 // cgr returns the conjure-go-runtime import path prefix for the configured version.

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -15,44 +15,79 @@
 package snip
 
 import (
+	"fmt"
+
 	"github.com/dave/jennifer/jen"
 )
 
 const (
 	pal = "github.com/palantir/"
-	cgr = pal + "conjure-go-runtime/v2/"
-	wgs = pal + "witchcraft-go-server/v2/"
 	wgl = pal + "witchcraft-go-logging/"
 )
 
-var DefaultImportsToPackageNames = map[string]string{
-	cgr + "conjure-go-client/httpclient":   "httpclient",
-	cgr + "conjure-go-contract/codecs":     "codecs",
-	cgr + "conjure-go-contract/errors":     "errors",
-	cgr + "conjure-go-server/httpserver":   "httpserver",
-	pal + "pkg/binary":                     "binary",
-	pal + "pkg/bearertoken":                "bearertoken",
-	pal + "pkg/boolean":                    "boolean",
-	pal + "pkg/datetime":                   "datetime",
-	pal + "pkg/rid":                        "rid",
-	pal + "pkg/safelong":                   "safelong",
-	pal + "pkg/safejson":                   "safejson",
-	pal + "pkg/safeyaml":                   "safeyaml",
-	pal + "pkg/uuid":                       "uuid",
-	pal + "witchcraft-go-error":            "werror",
-	pal + "witchcraft-go-params":           "wparams",
-	wgl + "wlog":                           "wlog",
-	wgl + "wlog-zap":                       "wlogzap",
-	wgl + "wlog/evtlog/evt2log":            "evt2log",
-	wgl + "wlog/svclog/svc1log":            "svc1log",
-	wgl + "wlog/trclog/trc1log":            "trc1log",
-	pal + "witchcraft-go-tracing/wtracing": "wtracing",
-	pal + "witchcraft-go-tracing/wzipkin":  "wzipkin",
-	wgs + "witchcraft/wresource":           "wresource",
-	wgs + "wrouter":                        "wrouter",
-	"gopkg.in/yaml.v3":                     "yaml",
-	"github.com/spf13/cobra":               "cobra",
-	"github.com/spf13/pflag":               "pflag",
+var (
+	// cgrVersion controls which version of conjure-go-runtime to use in generated imports.
+	// Defaults to 2. Set via SetCGRVersion before generation.
+	cgrVersion = 2
+	// wgsVersion controls which version of witchcraft-go-server to use in generated imports.
+	// Defaults to 2. Set via SetWGSVersion before generation.
+	wgsVersion = 2
+)
+
+// SetCGRVersion sets the version of conjure-go-runtime to use in generated imports.
+// Valid values are 2 or 3.
+func SetCGRVersion(version int) {
+	cgrVersion = version
+}
+
+// SetWGSVersion sets the version of witchcraft-go-server to use in generated imports.
+// Valid values are 2 or 3.
+func SetWGSVersion(version int) {
+	wgsVersion = version
+}
+
+// cgr returns the conjure-go-runtime import path prefix for the configured version.
+func cgr() string {
+	return fmt.Sprintf("%sconjure-go-runtime/v%d/", pal, cgrVersion)
+}
+
+// wgs returns the witchcraft-go-server import path prefix for the configured version.
+func wgs() string {
+	return fmt.Sprintf("%switchcraft-go-server/v%d/", pal, wgsVersion)
+}
+
+// ImportsToPackageNames returns a map of import paths to package names for use with jennifer.
+// This must be called after SetCGRVersion/SetWGSVersion to get the correct version-specific paths.
+func ImportsToPackageNames() map[string]string {
+	return map[string]string{
+		cgr() + "conjure-go-client/httpclient": "httpclient",
+		cgr() + "conjure-go-contract/codecs":   "codecs",
+		cgr() + "conjure-go-contract/errors":   "errors",
+		cgr() + "conjure-go-server/httpserver": "httpserver",
+		pal + "pkg/binary":                     "binary",
+		pal + "pkg/bearertoken":                "bearertoken",
+		pal + "pkg/boolean":                    "boolean",
+		pal + "pkg/datetime":                   "datetime",
+		pal + "pkg/rid":                        "rid",
+		pal + "pkg/safelong":                   "safelong",
+		pal + "pkg/safejson":                   "safejson",
+		pal + "pkg/safeyaml":                   "safeyaml",
+		pal + "pkg/uuid":                       "uuid",
+		pal + "witchcraft-go-error":            "werror",
+		pal + "witchcraft-go-params":           "wparams",
+		wgl + "wlog":                           "wlog",
+		wgl + "wlog-zap":                       "wlogzap",
+		wgl + "wlog/evtlog/evt2log":            "evt2log",
+		wgl + "wlog/svclog/svc1log":            "svc1log",
+		wgl + "wlog/trclog/trc1log":            "trc1log",
+		pal + "witchcraft-go-tracing/wtracing": "wtracing",
+		pal + "witchcraft-go-tracing/wzipkin":  "wzipkin",
+		wgs() + "witchcraft/wresource":         "wresource",
+		wgs() + "wrouter":                      "wrouter",
+		"gopkg.in/yaml.v3":                     "yaml",
+		"github.com/spf13/cobra":               "cobra",
+		"github.com/spf13/pflag":               "pflag",
+	}
 }
 
 // A set of imported references included in generated code.
@@ -91,53 +126,149 @@ var (
 	StrconvAtoi         = jen.Qual("strconv", "Atoi").Clone
 	StrconvParseBool    = jen.Qual("strconv", "ParseBool").Clone
 	StrconvParseFloat   = jen.Qual("strconv", "ParseFloat").Clone
+)
 
-	CGRClientClient                            = jen.Qual(cgr+"conjure-go-client/httpclient", "Client").Clone
-	CGRClientNewClient                         = jen.Qual(cgr+"conjure-go-client/httpclient", "NewClient").Clone
-	CGRClientClientConfig                      = jen.Qual(cgr+"conjure-go-client/httpclient", "ClientConfig").Clone
-	CGRClientWithConfig                        = jen.Qual(cgr+"conjure-go-client/httpclient", "WithConfig").Clone
-	CGRClientRequestBody                       = jen.Qual(cgr+"conjure-go-client/httpclient", "RequestBody").Clone
-	CGRClientRequestBodyInMemory               = jen.Qual(cgr+"conjure-go-client/httpclient", "RequestBodyInMemory").Clone
-	CGRClientRequestBodyStreamOnce             = jen.Qual(cgr+"conjure-go-client/httpclient", "RequestBodyStreamOnce").Clone
-	CGRClientRequestBodyStreamWithReplay       = jen.Qual(cgr+"conjure-go-client/httpclient", "RequestBodyStreamWithReplay").Clone
-	CGRClientRequestParam                      = jen.Qual(cgr+"conjure-go-client/httpclient", "RequestParam").Clone
-	CGRClientTokenProvider                     = jen.Qual(cgr+"conjure-go-client/httpclient", "TokenProvider").Clone
-	CGRClientWithBinaryRequestBody             = jen.Qual(cgr+"conjure-go-client/httpclient", "WithBinaryRequestBody").Clone
-	CGRClientWithHeader                        = jen.Qual(cgr+"conjure-go-client/httpclient", "WithHeader").Clone
-	CGRClientWithJSONRequest                   = jen.Qual(cgr+"conjure-go-client/httpclient", "WithJSONRequest").Clone
-	CGRClientWithJSONResponse                  = jen.Qual(cgr+"conjure-go-client/httpclient", "WithJSONResponse").Clone
-	CGRClientWithPathf                         = jen.Qual(cgr+"conjure-go-client/httpclient", "WithPathf").Clone
-	CGRClientWithQueryValues                   = jen.Qual(cgr+"conjure-go-client/httpclient", "WithQueryValues").Clone
-	CGRClientWithRPCMethodName                 = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRPCMethodName").Clone
-	CGRClientWithRawResponseBody               = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRawResponseBody").Clone
-	CGRClientWithRequestConjureErrorDecoder    = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRequestConjureErrorDecoder").Clone
-	CGRClientWithRequestMethod                 = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRequestMethod").Clone
-	CGRCodecsBinary                            = jen.Qual(cgr+"conjure-go-contract/codecs", "Binary").Clone
-	CGRCodecsJSON                              = jen.Qual(cgr+"conjure-go-contract/codecs", "JSON").Clone
-	CGRErrorsPermissionDenied                  = jen.Qual(cgr+"conjure-go-contract/errors", "PermissionDenied").Clone
-	CGRErrorsInvalidArgument                   = jen.Qual(cgr+"conjure-go-contract/errors", "InvalidArgument").Clone
-	CGRErrorsNotFound                          = jen.Qual(cgr+"conjure-go-contract/errors", "NotFound").Clone
-	CGRErrorsConflict                          = jen.Qual(cgr+"conjure-go-contract/errors", "Conflict").Clone
-	CGRErrorsRequestEntityTooLarge             = jen.Qual(cgr+"conjure-go-contract/errors", "RequestEntityTooLarge").Clone
-	CGRErrorsFailedPrecondition                = jen.Qual(cgr+"conjure-go-contract/errors", "FailedPrecondition").Clone
-	CGRErrorsInternal                          = jen.Qual(cgr+"conjure-go-contract/errors", "Internal").Clone
-	CGRErrorsTimeout                           = jen.Qual(cgr+"conjure-go-contract/errors", "Timeout").Clone
-	CGRErrorsCustomClient                      = jen.Qual(cgr+"conjure-go-contract/errors", "CustomClient").Clone
-	CGRErrorsCustomServer                      = jen.Qual(cgr+"conjure-go-contract/errors", "CustomServer").Clone
-	CGRErrorsErrorCode                         = jen.Qual(cgr+"conjure-go-contract/errors", "ErrorCode").Clone
-	CGRErrorsGetConjureError                   = jen.Qual(cgr+"conjure-go-contract/errors", "GetConjureError").Clone
-	CGRErrorsNewInternal                       = jen.Qual(cgr+"conjure-go-contract/errors", "NewInternal").Clone
-	CGRErrorsNewInvalidArgument                = jen.Qual(cgr+"conjure-go-contract/errors", "NewInvalidArgument").Clone
-	CGRErrorsNewReflectTypeConjureErrorDecoder = jen.Qual(cgr+"conjure-go-contract/errors", "NewReflectTypeConjureErrorDecoder").Clone
-	CGRErrorsConjureErrorDecoder               = jen.Qual(cgr+"conjure-go-contract/errors", "ConjureErrorDecoder").Clone
-	CGRErrorsSerializableError                 = jen.Qual(cgr+"conjure-go-contract/errors", "SerializableError").Clone
-	CGRErrorsWrapWithInvalidArgument           = jen.Qual(cgr+"conjure-go-contract/errors", "WrapWithInvalidArgument").Clone
-	CGRErrorsWrapWithPermissionDenied          = jen.Qual(cgr+"conjure-go-contract/errors", "WrapWithPermissionDenied").Clone
-	CGRHTTPServerErrHandler                    = jen.Qual(cgr+"conjure-go-server/httpserver", "ErrHandler").Clone
-	CGRHTTPServerNewJSONHandler                = jen.Qual(cgr+"conjure-go-server/httpserver", "NewJSONHandler").Clone
-	CGRHTTPServerParseBearerTokenHeader        = jen.Qual(cgr+"conjure-go-server/httpserver", "ParseBearerTokenHeader").Clone
-	CGRHTTPServerStatusCodeMapper              = jen.Qual(cgr+"conjure-go-server/httpserver", "StatusCodeMapper").Clone
+// Version-dependent imports for conjure-go-runtime.
+// These are functions rather than vars so they use the current runtimeVersion.
 
+func CGRClientClient() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "Client")
+}
+func CGRClientNewClient() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "NewClient")
+}
+func CGRClientClientConfig() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "ClientConfig")
+}
+func CGRClientWithConfig() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithConfig")
+}
+func CGRClientRequestBody() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "RequestBody")
+}
+func CGRClientRequestBodyInMemory() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "RequestBodyInMemory")
+}
+func CGRClientRequestBodyStreamOnce() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "RequestBodyStreamOnce")
+}
+func CGRClientRequestBodyStreamWithReplay() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "RequestBodyStreamWithReplay")
+}
+func CGRClientRequestParam() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "RequestParam")
+}
+func CGRClientTokenProvider() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "TokenProvider")
+}
+func CGRClientWithBinaryRequestBody() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithBinaryRequestBody")
+}
+func CGRClientWithHeader() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithHeader")
+}
+func CGRClientWithJSONRequest() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithJSONRequest")
+}
+func CGRClientWithJSONResponse() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithJSONResponse")
+}
+func CGRClientWithPathf() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithPathf")
+}
+func CGRClientWithQueryValues() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithQueryValues")
+}
+func CGRClientWithRPCMethodName() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithRPCMethodName")
+}
+func CGRClientWithRawResponseBody() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithRawResponseBody")
+}
+func CGRClientWithRequestConjureErrorDecoder() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithRequestConjureErrorDecoder")
+}
+func CGRClientWithRequestMethod() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-client/httpclient", "WithRequestMethod")
+}
+func CGRCodecsBinary() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/codecs", "Binary")
+}
+func CGRCodecsJSON() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/codecs", "JSON")
+}
+func CGRErrorsPermissionDenied() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "PermissionDenied")
+}
+func CGRErrorsInvalidArgument() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "InvalidArgument")
+}
+func CGRErrorsNotFound() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "NotFound")
+}
+func CGRErrorsConflict() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "Conflict")
+}
+func CGRErrorsRequestEntityTooLarge() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "RequestEntityTooLarge")
+}
+func CGRErrorsFailedPrecondition() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "FailedPrecondition")
+}
+func CGRErrorsInternal() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "Internal")
+}
+func CGRErrorsTimeout() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "Timeout")
+}
+func CGRErrorsCustomClient() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "CustomClient")
+}
+func CGRErrorsCustomServer() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "CustomServer")
+}
+func CGRErrorsErrorCode() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "ErrorCode")
+}
+func CGRErrorsGetConjureError() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "GetConjureError")
+}
+func CGRErrorsNewInternal() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "NewInternal")
+}
+func CGRErrorsNewInvalidArgument() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "NewInvalidArgument")
+}
+func CGRErrorsNewReflectTypeConjureErrorDecoder() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "NewReflectTypeConjureErrorDecoder")
+}
+func CGRErrorsConjureErrorDecoder() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "ConjureErrorDecoder")
+}
+func CGRErrorsSerializableError() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "SerializableError")
+}
+func CGRErrorsWrapWithInvalidArgument() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "WrapWithInvalidArgument")
+}
+func CGRErrorsWrapWithPermissionDenied() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-contract/errors", "WrapWithPermissionDenied")
+}
+func CGRHTTPServerErrHandler() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-server/httpserver", "ErrHandler")
+}
+func CGRHTTPServerNewJSONHandler() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-server/httpserver", "NewJSONHandler")
+}
+func CGRHTTPServerParseBearerTokenHeader() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-server/httpserver", "ParseBearerTokenHeader")
+}
+func CGRHTTPServerStatusCodeMapper() *jen.Statement {
+	return jen.Qual(cgr()+"conjure-go-server/httpserver", "StatusCodeMapper")
+}
+
+// Static imports that don't depend on runtime version.
+var (
 	BinaryBinary                   = jen.Qual(pal+"pkg/binary", "Binary").Clone
 	BinaryNew                      = jen.Qual(pal+"pkg/binary", "New").Clone
 	BearerTokenToken               = jen.Qual(pal+"pkg/bearertoken", "Token").Clone
@@ -176,17 +307,6 @@ var (
 	WGTContextWithTracer           = jen.Qual(pal+"witchcraft-go-tracing/wtracing", "ContextWithTracer").Clone
 	WGTZipkinNewTracer             = jen.Qual(pal+"witchcraft-go-tracing/wzipkin", "NewTracer").Clone
 
-	WresourceNew                 = jen.Qual(wgs+"witchcraft/wresource", "New").Clone
-	WrouterPathParams            = jen.Qual(wgs+"wrouter", "PathParams").Clone
-	WrouterRouteParam            = jen.Qual(wgs+"wrouter", "RouteParam").Clone
-	WrouterRouter                = jen.Qual(wgs+"wrouter", "Router").Clone
-	WrouterForbiddenHeaderParams = jen.Qual(wgs+"wrouter", "ForbiddenHeaderParams").Clone
-	WrouterForbiddenPathParams   = jen.Qual(wgs+"wrouter", "ForbiddenPathParams").Clone
-	WrouterForbiddenQueryParams  = jen.Qual(wgs+"wrouter", "ForbiddenQueryParams").Clone
-	WrouterSafeHeaderParams      = jen.Qual(wgs+"wrouter", "SafeHeaderParams").Clone
-	WrouterSafePathParams        = jen.Qual(wgs+"wrouter", "SafePathParams").Clone
-	WrouterSafeQueryParams       = jen.Qual(wgs+"wrouter", "SafeQueryParams").Clone
-
 	TAny          = jen.Op("[").Id("T").Id("any").Op("]").Clone
 	YamlUnmarshal = jen.Qual("gopkg.in/yaml.v3", "Unmarshal").Clone
 
@@ -194,3 +314,37 @@ var (
 
 	PflagsFlagset = jen.Qual("github.com/spf13/pflag", "FlagSet").Clone
 )
+
+// Version-dependent imports for witchcraft-go-server.
+// These are functions rather than vars so they use the current runtimeVersion.
+
+func WresourceNew() *jen.Statement {
+	return jen.Qual(wgs()+"witchcraft/wresource", "New")
+}
+func WrouterPathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "PathParams")
+}
+func WrouterRouteParam() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "RouteParam")
+}
+func WrouterRouter() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "Router")
+}
+func WrouterForbiddenHeaderParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenHeaderParams")
+}
+func WrouterForbiddenPathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenPathParams")
+}
+func WrouterForbiddenQueryParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "ForbiddenQueryParams")
+}
+func WrouterSafeHeaderParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafeHeaderParams")
+}
+func WrouterSafePathParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafePathParams")
+}
+func WrouterSafeQueryParams() *jen.Statement {
+	return jen.Qual(wgs()+"wrouter", "SafeQueryParams")
+}


### PR DESCRIPTION
## Before this PR
Generated code only used WGS/CGR v2 module versions which blocked the migration of the new V3 modules. A major version is usually how new module versions are introduced, but given ongoing work in `godel-conjure-plugin` we want to avoid a major rev right now. Alternatively, we can expose a configuration point to allow controlling which module versions are used such that users can generate v3 module code if they migrate to use WGS/CGR v3 for the rest of the codebase

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow generated code to use WGS/CGR V2 or V3 module versions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/841)
<!-- Reviewable:end -->
