### PR TITLE
fix: Servers initialize nil collection responses before encoding

### DIFF
--- a/conjure/serverwriter.go
+++ b/conjure/serverwriter.go
@@ -491,8 +491,11 @@ func astForHandlerExecImplAndReturn(g *jen.Group, serviceName string, endpointDe
 			jen.Id(responseWriterVarName).Dot("WriteHeader").Call(snip.HTTPStatusNoContent()),
 			jen.Return(jen.Nil()),
 		)
+	} else if respType.IsCollection() {
+		g.If(respArg.Clone().Op("==").Nil()).Block(
+			respArg.Clone().Op("=").Add(respType.Make()),
+		)
 	}
-
 	codec := snip.CGRCodecsJSON()
 	if respType.IsBinary() {
 		codec = snip.CGRCodecsBinary()

--- a/integration_test/testgenerated/binary/api/servers.conjure.go
+++ b/integration_test/testgenerated/binary/api/servers.conjure.go
@@ -153,6 +153,9 @@ func (t *testServiceHandler) HandleBinaryList(rw http.ResponseWriter, req *http.
 	if err != nil {
 		return err
 	}
+	if respArg == nil {
+		respArg = make([][]byte, 0)
+	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
 }

--- a/integration_test/testgenerated/cli/api/servers.conjure.go
+++ b/integration_test/testgenerated/cli/api/servers.conjure.go
@@ -143,6 +143,9 @@ func (t *testServiceHandler) HandleEchoStrings(rw http.ResponseWriter, req *http
 	if err != nil {
 		return err
 	}
+	if respArg == nil {
+		respArg = make([]string, 0)
+	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
 }
@@ -237,6 +240,9 @@ func (t *testServiceHandler) HandleGetListBoolean(rw http.ResponseWriter, req *h
 	if err != nil {
 		return err
 	}
+	if respArg == nil {
+		respArg = make([]bool, 0)
+	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
 }
@@ -250,6 +256,9 @@ func (t *testServiceHandler) HandlePutMapStringString(rw http.ResponseWriter, re
 	if err != nil {
 		return err
 	}
+	if respArg == nil {
+		respArg = make(map[string]string)
+	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
 }
@@ -262,6 +271,9 @@ func (t *testServiceHandler) HandlePutMapStringAny(rw http.ResponseWriter, req *
 	respArg, err := t.impl.PutMapStringAny(req.Context(), myParamArg)
 	if err != nil {
 		return err
+	}
+	if respArg == nil {
+		respArg = make(map[string]interface{})
 	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)

--- a/integration_test/testgenerated/server/api/servers.conjure.go
+++ b/integration_test/testgenerated/server/api/servers.conjure.go
@@ -177,6 +177,9 @@ func (t *testServiceHandler) HandleEchoStrings(rw http.ResponseWriter, req *http
 	if err != nil {
 		return err
 	}
+	if respArg == nil {
+		respArg = make([]string, 0)
+	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)
 }
@@ -348,6 +351,9 @@ func (t *testServiceHandler) HandleQueryParamSetDateTime(rw http.ResponseWriter,
 	respArg, err := t.impl.QueryParamSetDateTime(req.Context(), bearertoken.Token(authHeader), myQueryParam1Arg)
 	if err != nil {
 		return err
+	}
+	if respArg == nil {
+		respArg = make([]datetime.DateTime, 0)
 	}
 	rw.Header().Add("Content-Type", codecs.JSON.ContentType())
 	return codecs.JSON.Encode(rw, respArg)

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -242,6 +242,25 @@ func TestEchoOptionalListAlias(t *testing.T) {
 	})
 }
 
+func TestNilCollectionResponse(t *testing.T) {
+	wlog.SetDefaultLoggerProvider(wlog.NewJSONMarshalLoggerProvider())
+	router := wrouter.New(whttprouter.New())
+	err := api.RegisterRoutesTestService(router, testServerImpl{})
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	// Send JSON null body which decodes to a nil []string.
+	// The server handler should respond with [] (empty JSON array), not null.
+	resp, err := http.Post(server.URL+"/echo", "application/json", bytes.NewReader([]byte("null")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `[]`, string(respBody))
+}
+
 func TestEchoQueryParamSet(t *testing.T) {
 	wlog.SetDefaultLoggerProvider(wlog.NewJSONMarshalLoggerProvider())
 	router := wrouter.New(whttprouter.New())
@@ -295,7 +314,7 @@ func (t testServerImpl) Echo(ctx context.Context, req *http.Request, cookieToken
 }
 
 func (t testServerImpl) EchoStrings(ctx context.Context, bodyArg []string) ([]string, error) {
-	panic("implement me")
+	return bodyArg, nil
 }
 
 func (t testServerImpl) EchoCustomObject(ctx context.Context, bodyArg *api.CustomObject) (*api.CustomObject, error) {

--- a/integration_test/testgenerated/server/server_test.go
+++ b/integration_test/testgenerated/server/server_test.go
@@ -254,7 +254,7 @@ func TestNilCollectionResponse(t *testing.T) {
 	// The server handler should respond with [] (empty JSON array), not null.
 	resp, err := http.Post(server.URL+"/echo", "application/json", bytes.NewReader([]byte("null")))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { assert.NoError(t, resp.Body.Close()) }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
Per the conjure spec, we should never serialize collections as `null` but as their empty form `[]` or `{}`. This is already handled in named types' custom marshal functions, but not for plain collection types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/908)
<!-- Reviewable:end -->
