### PR TITLE
Add --strict-unmarshal flag to reject unknown JSON fields

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,17 +24,19 @@ import (
 )
 
 const (
-	outputDirFlagName    = "output"
-	serverFlagName       = "server"
-	funcsVisitorFlagName = "funcs-visitor"
+	outputDirFlagName        = "output"
+	serverFlagName           = "server"
+	funcsVisitorFlagName     = "funcs-visitor"
+	strictUnmarshalFlagName  = "strict-unmarshal"
 )
 
 var (
-	version             = "unspecified"
-	debug               bool
-	outputDirFlagVar    string
-	serverFlagVar       bool
-	funcsVisitorFlagVar bool
+	version                = "unspecified"
+	debug                  bool
+	outputDirFlagVar       string
+	serverFlagVar          bool
+	funcsVisitorFlagVar    bool
+	strictUnmarshalFlagVar bool
 )
 
 var rootCmd = &cobra.Command{
@@ -55,6 +57,7 @@ func init() {
 	rootCmd.Flags().StringVar(&outputDirFlagVar, outputDirFlagName, ".", "base directory into which generated Conjure is written")
 	rootCmd.Flags().BoolVar(&serverFlagVar, serverFlagName, false, "enable witchcraft-go server generation")
 	rootCmd.Flags().BoolVar(&funcsVisitorFlagVar, funcsVisitorFlagName, false, "enable witchcraft-go funcs visitor generation")
+	rootCmd.Flags().BoolVar(&strictUnmarshalFlagVar, strictUnmarshalFlagName, false, "generate strict UnmarshalJSON methods that reject unknown fields")
 }
 
 func Generate(irFile, outDir string) error {
@@ -68,6 +71,7 @@ func Generate(irFile, outDir string) error {
 	output := conjure.OutputConfiguration{
 		GenerateFuncsVisitor: funcsVisitorFlagVar,
 		GenerateServer:       serverFlagVar,
+		StrictUnmarshalJSON:  strictUnmarshalFlagVar,
 		OutputDir:            outDir,
 	}
 	if err := conjure.Generate(conjureDefinition, output); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	outputDirFlagName        = "output"
-	serverFlagName           = "server"
-	funcsVisitorFlagName     = "funcs-visitor"
-	strictUnmarshalFlagName  = "strict-unmarshal"
+	outputDirFlagName       = "output"
+	serverFlagName          = "server"
+	funcsVisitorFlagName    = "funcs-visitor"
+	strictUnmarshalFlagName = "strict-unmarshal"
 )
 
 var (

--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -123,7 +123,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			objectFile := newJenFile(pkg, def, errorRegistryImportPath)
 			safetyCache := make(map[types.Type]spec.LogSafety)
 			for _, object := range pkg.Objects {
-				writeObjectType(objectFile.Group, object, safetyCache)
+				writeObjectType(objectFile.Group, object, safetyCache, cfg.StrictUnmarshalJSON)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "structs.conjure.go"), objectFile))
 		}
@@ -132,7 +132,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			goUnionGenericsFile := newJenFile(pkg, def, errorRegistryImportPath)
 			goUnionGenericsFile.Comment("//go:build go1.18")
 			for _, union := range pkg.Unions {
-				writeUnionType(unionFile.Group, union, cfg.GenerateFuncsVisitor)
+				writeUnionType(unionFile.Group, union, cfg.GenerateFuncsVisitor, cfg.StrictUnmarshalJSON)
 				writeUnionTypeWithGenerics(goUnionGenericsFile.Group, union, cfg.GenerateFuncsVisitor)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "unions.conjure.go"), unionFile))
@@ -141,7 +141,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 		if len(pkg.Errors) > 0 {
 			errorFile := newJenFile(pkg, def, errorRegistryImportPath)
 			for _, errorDef := range pkg.Errors {
-				writeErrorType(errorFile.Group, errorDef)
+				writeErrorType(errorFile.Group, errorDef, cfg.StrictUnmarshalJSON)
 			}
 			astErrorInitFunc(errorFile.Group, pkg.Errors, errorRegistryImportPath)
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "errors.conjure.go"), errorFile))

--- a/conjure/errorwriter.go
+++ b/conjure/errorwriter.go
@@ -33,8 +33,8 @@ const (
 	errorNameParam       = "errorName"
 )
 
-func writeErrorType(file *jen.Group, def *types.ErrorDefinition) {
-	astErrorInternalStructType(file, def)
+func writeErrorType(file *jen.Group, def *types.ErrorDefinition, strictUnmarshal bool) {
+	astErrorInternalStructType(file, def, strictUnmarshal)
 	astErrorConstructorFuncs(file, def)
 	astErrorExportedStructType(file, def)
 	astIsErrorTypeFunc(file, def)
@@ -56,7 +56,7 @@ func writeErrorType(file *jen.Group, def *types.ErrorDefinition) {
 }
 
 // Create private *myInternal object containing known params.
-func astErrorInternalStructType(file *jen.Group, def *types.ErrorDefinition) {
+func astErrorInternalStructType(file *jen.Group, def *types.ErrorDefinition, strictUnmarshal bool) {
 	allArgs := append(append([]*types.Field{}, def.SafeArgs...), def.UnsafeArgs...)
 	// Use object generator to create a struct implementing JSON encoding for the error.
 	safetyCache := make(map[types.Type]spec.LogSafety)
@@ -65,7 +65,7 @@ func astErrorInternalStructType(file *jen.Group, def *types.ErrorDefinition) {
 		Fields:     allArgs,
 		ConjurePkg: def.ConjurePkg,
 		ImportPath: def.ImportPath,
-	}, safetyCache)
+	}, safetyCache, strictUnmarshal)
 }
 
 // Declare New and Wrap constructors

--- a/conjure/objectwriter.go
+++ b/conjure/objectwriter.go
@@ -41,7 +41,7 @@ func logSafetyToAnnotation(safety spec.LogSafety_Value) string {
 	}
 }
 
-func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache map[types.Type]spec.LogSafety) {
+func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache map[types.Type]spec.LogSafety, strictUnmarshal bool) {
 	// Declare struct type with fields
 	containsCollection := false // If contains collection, we need JSON methods to initialize empty values.
 
@@ -95,10 +95,7 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache m
 			rawVarName := "raw" + objectDef.Name
 			methodBody.Type().Id(tmpAliasName).Id(objectDef.Name)
 			methodBody.Var().Id(rawVarName).Id(tmpAliasName)
-			methodBody.If(jen.Err().Op(":=").Add(snip.SafeJSONUnmarshal()).Call(jen.Id(dataVarName), jen.Op("&").Id(rawVarName)),
-				jen.Err().Op("!=").Nil()).Block(
-				jen.Return(jen.Err()),
-			)
+			writeUnmarshalDecodeBlock(methodBody, rawVarName, strictUnmarshal)
 			writeStructMarshalInitDecls(methodBody, objectDef.Fields, rawVarName)
 			methodBody.Op("*").Id(objReceiverName).Op("=").Id(objectDef.Name).Call(jen.Id(rawVarName))
 			methodBody.Return(jen.Nil())
@@ -107,6 +104,23 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache m
 
 	file.Add(snip.MethodMarshalYAML(objReceiverName, objectDef.Name))
 	file.Add(snip.MethodUnmarshalYAML(objReceiverName, objectDef.Name))
+}
+
+func writeUnmarshalDecodeBlock(methodBody *jen.Group, rawVarName string, strictUnmarshal bool) {
+	if strictUnmarshal {
+		methodBody.Id("dec").Op(":=").Add(snip.JSONNewDecoder()).Call(snip.ByteReader().Call(jen.Id(dataVarName)))
+		methodBody.Id("dec").Dot("UseNumber").Call()
+		methodBody.Id("dec").Dot("DisallowUnknownFields").Call()
+		methodBody.If(jen.Err().Op(":=").Id("dec").Dot("Decode").Call(jen.Op("&").Id(rawVarName)),
+			jen.Err().Op("!=").Nil()).Block(
+			jen.Return(jen.Err()),
+		)
+	} else {
+		methodBody.If(jen.Err().Op(":=").Add(snip.SafeJSONUnmarshal()).Call(jen.Id(dataVarName), jen.Op("&").Id(rawVarName)),
+			jen.Err().Op("!=").Nil()).Block(
+			jen.Return(jen.Err()),
+		)
+	}
 }
 
 func writeStructMarshalInitDecls(methodBody *jen.Group, fields []*types.Field, rawVarName string) {

--- a/conjure/objectwriter_test.go
+++ b/conjure/objectwriter_test.go
@@ -695,10 +695,84 @@ func (o *MyObject) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		t.Run(tc.name, func(t *testing.T) {
 			f := jen.NewFile("testpkg")
 			safetyCache := make(map[types.Type]spec.LogSafety)
-			writeObjectType(f.Group, tc.in, safetyCache)
+			writeObjectType(f.Group, tc.in, safetyCache, false)
 			var buf bytes.Buffer
 			assert.NoError(t, f.Render(&buf))
 			assert.Equal(t, tc.Out, buf.String())
 		})
 	}
+}
+
+func TestObjectWriter_StrictUnmarshal(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	safetyCache := make(map[types.Type]spec.LogSafety)
+	writeObjectType(f.Group, &types.ObjectType{
+		Name: "User",
+		Fields: []*types.Field{
+			{
+				Name: "UserName",
+				Type: types.String{},
+			},
+			{
+				Name: "UserAliases",
+				Type: &types.List{Item: &types.AliasType{
+					Item: types.String{},
+					Name: "UserAlias",
+				}},
+			},
+		},
+	}, safetyCache, true)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	assert.Equal(t, `package testpkg
+
+import (
+	"bytes"
+	"encoding/json"
+	safejson "github.com/palantir/pkg/safejson"
+	safeyaml "github.com/palantir/pkg/safeyaml"
+)
+
+type User struct {
+	UserName    string      `+"`json:\"UserName\"`"+`
+	UserAliases []UserAlias `+"`json:\"UserAliases\"`"+`
+}
+
+func (o User) MarshalJSON() ([]byte, error) {
+	if o.UserAliases == nil {
+		o.UserAliases = make([]UserAlias, 0)
+	}
+	type _tmpUser User
+	return safejson.Marshal(_tmpUser(o))
+}
+func (o *User) UnmarshalJSON(data []byte) error {
+	type _tmpUser User
+	var rawUser _tmpUser
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rawUser); err != nil {
+		return err
+	}
+	if rawUser.UserAliases == nil {
+		rawUser.UserAliases = make([]UserAlias, 0)
+	}
+	*o = User(rawUser)
+	return nil
+}
+func (o User) MarshalYAML() (interface{}, error) {
+	jsonBytes, err := safejson.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	return safeyaml.JSONtoYAMLMapSlice(jsonBytes)
+}
+func (o *User) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	jsonBytes, err := safeyaml.UnmarshalerToJSONBytes(unmarshal)
+	if err != nil {
+		return err
+	}
+	return safejson.Unmarshal(jsonBytes, *&o)
+}
+`, buf.String())
 }

--- a/conjure/output_configuration.go
+++ b/conjure/output_configuration.go
@@ -20,4 +20,5 @@ type OutputConfiguration struct {
 	GenerateCLI          bool
 	OutputDir            string
 	ExportErrorDecoder   bool
+	StrictUnmarshalJSON  bool
 }

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -63,6 +63,7 @@ func ImportsToPackageNames() map[string]string {
 // This ensures there are no side effects caused by mutating the global variables.
 var (
 	ByteReader          = jen.Qual("bytes", "NewReader").Clone
+	JSONNewDecoder      = jen.Qual("encoding/json", "NewDecoder").Clone
 	Context             = jen.Qual("context", "Context").Clone
 	ContextTODO         = jen.Qual("context", "TODO").Clone
 	ContextBackground   = jen.Qual("context", "Background").Clone

--- a/conjure/unionwriter.go
+++ b/conjure/unionwriter.go
@@ -28,7 +28,7 @@ const (
 	withContextSuffix = "WithContext"
 )
 
-func writeUnionType(file *jen.Group, unionDef *types.UnionType, genAcceptFuncs bool) {
+func writeUnionType(file *jen.Group, unionDef *types.UnionType, genAcceptFuncs bool, strictUnmarshal bool) {
 	// Declare exported union struct type
 	file.Add(unionDef.CommentLine()).
 		Type().
@@ -39,14 +39,14 @@ func writeUnionType(file *jen.Group, unionDef *types.UnionType, genAcceptFuncs b
 		}
 	})
 
-	unionSerializationFuncs(file, unionDef)
+	unionSerializationFuncs(file, unionDef, strictUnmarshal)
 	// Declare Accept/AcceptWithContext methods & visitor interfaces
 	unionVisitorFuncs(file, unionDef, genAcceptFuncs)
 	// Declare New*From* constructor functions
 	unionConstructorFuncs(file, unionDef)
 }
 
-func unionSerializationFuncs(file *jen.Group, unionDef *types.UnionType) {
+func unionSerializationFuncs(file *jen.Group, unionDef *types.UnionType, strictUnmarshal bool) {
 	// Declare deserializer struct type
 	file.Type().
 		Id(unionDeserializerStructName(unionDef.Name)).StructFunc(func(structFields *jen.Group) {
@@ -109,14 +109,11 @@ func unionSerializationFuncs(file *jen.Group, unionDef *types.UnionType) {
 	))
 
 	// Declare UnmarshalJSON method
-	file.Add(snip.MethodUnmarshalJSON(unionReceiverName, unionDef.Name).Block(
-		jen.Var().Id("deser").Id(unionDeserializerStructName(unionDef.Name)),
-		jen.If(
-			jen.Err().Op(":=").Add(snip.SafeJSONUnmarshal().Call(jen.Id(dataVarName), jen.Op("&").Id("deser"))),
-			jen.Err().Op("!=").Nil(),
-		).Block(jen.Return(jen.Err())),
-		jen.Op("*").Id(unionReceiverName).Op("=").Id("deser").Dot("toStruct").Call(),
-		jen.Switch(jen.Id(unionReceiverName).Dot("typ")).BlockFunc(func(cases *jen.Group) {
+	file.Add(snip.MethodUnmarshalJSON(unionReceiverName, unionDef.Name).BlockFunc(func(methodBody *jen.Group) {
+		methodBody.Var().Id("deser").Id(unionDeserializerStructName(unionDef.Name))
+		writeUnmarshalDecodeBlock(methodBody, "deser", strictUnmarshal)
+		methodBody.Op("*").Id(unionReceiverName).Op("=").Id("deser").Dot("toStruct").Call()
+		methodBody.Switch(jen.Id(unionReceiverName).Dot("typ")).BlockFunc(func(cases *jen.Group) {
 			for _, fieldDef := range unionDef.Fields {
 				cases.Case(jen.Lit(fieldDef.Name)).BlockFunc(func(caseBody *jen.Group) {
 					if !fieldDef.Type.IsOptional() {
@@ -127,9 +124,9 @@ func unionSerializationFuncs(file *jen.Group, unionDef *types.UnionType) {
 					}
 				})
 			}
-		}),
-		jen.Return(jen.Nil()),
-	))
+		})
+		methodBody.Return(jen.Nil())
+	}))
 
 	// Declare yaml methods
 	file.Add(snip.MethodMarshalYAML(unionReceiverName, unionDef.Name))

--- a/conjure/unionwriter_test.go
+++ b/conjure/unionwriter_test.go
@@ -199,6 +199,29 @@ func (u *MyUnionWithOptionalWithT[T]) ErrorOnUnknown(typeName string) (T, error)
 `, buf.String())
 }
 
+func TestUnionWriter_writeUnionType_strictUnmarshal(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	writeUnionType(f.Group, testUnionType, false, true)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	output := buf.String()
+	assert.Contains(t, output, "json.NewDecoder(bytes.NewReader(data))")
+	assert.Contains(t, output, "dec.UseNumber()")
+	assert.Contains(t, output, "dec.DisallowUnknownFields()")
+	assert.Contains(t, output, "dec.Decode(&deser)")
+	assert.NotContains(t, output, "safejson.Unmarshal(data,")
+}
+
+func TestUnionWriter_writeUnionType_nonStrictUnmarshal(t *testing.T) {
+	f := jen.NewFile("testpkg")
+	writeUnionType(f.Group, testUnionType, false, false)
+	var buf bytes.Buffer
+	assert.NoError(t, f.Render(&buf))
+	output := buf.String()
+	assert.Contains(t, output, "safejson.Unmarshal(data, &deser)")
+	assert.NotContains(t, output, "DisallowUnknownFields")
+}
+
 func TestUnionWriter_writeUnionTypeWithGenerics_withAcceptFuncs(t *testing.T) {
 	f := jen.NewFile("testpkg")
 	writeUnionTypeWithGenerics(f.Group, testUnionType, true)


### PR DESCRIPTION
## Before this PR
We did not have the ability to generate code with strict unmarshaling

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Objects for which conjure generates custom JSON unmarshallers support optional rejection of unknown fields
==COMMIT_MSG==

## Possible downsides?
This doesn't automatically work for objects that we dont generate custom unmarshallers for and for those, the consumer needs to set the appropriate flags on the JSON decoder they use. With new golang Json encoder library work, there will be a way to get decoder options piped through to custom unmarshaller code, at which point we can switch conjure-go to use that and deprecate/remove the CLI flag that is being added in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/931)
<!-- Reviewable:end -->
