### PR TITLE
Feature: Add ErrorParameterFormatJSON option

### DIFF
--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -150,7 +150,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 		if hasServices {
 			serviceFile := newJenFile(pkg, def, errorRegistryImportPath)
 			for _, service := range pkg.Services {
-				writeServiceType(serviceFile.Group, service, errorRegistryImportPath)
+				writeServiceType(serviceFile.Group, service, errorRegistryImportPath, cfg.ErrorParameterFormatJSON)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "services.conjure.go"), serviceFile))
 		}

--- a/conjure/output_configuration.go
+++ b/conjure/output_configuration.go
@@ -15,9 +15,10 @@
 package conjure
 
 type OutputConfiguration struct {
-	GenerateFuncsVisitor bool
-	GenerateServer       bool
-	GenerateCLI          bool
-	OutputDir            string
-	ExportErrorDecoder   bool
+	GenerateFuncsVisitor     bool
+	GenerateServer           bool
+	GenerateCLI              bool
+	OutputDir                string
+	ExportErrorDecoder       bool
+	ErrorParameterFormatJSON bool
 }

--- a/conjure/servicewriter.go
+++ b/conjure/servicewriter.go
@@ -47,12 +47,12 @@ var (
 	pathParamRegexp = regexp.MustCompile(regexp.QuoteMeta("{") + "[^}]+" + regexp.QuoteMeta("}"))
 )
 
-func writeServiceType(file *jen.Group, serviceDef *types.ServiceDefinition, errorRegistryImportPath string) {
+func writeServiceType(file *jen.Group, serviceDef *types.ServiceDefinition, errorRegistryImportPath string, errorParameterFormatJSON bool) {
 	file.Add(astForServiceInterface(serviceDef, false, false))
 	file.Add(astForClientStructDecl(serviceDef.Name))
 	file.Add(astForNewClientFunc(serviceDef.Name))
 	for _, endpointDef := range serviceDef.Endpoints {
-		file.Add(astForEndpointMethod(serviceDef.Name, endpointDef, errorRegistryImportPath, false))
+		file.Add(astForEndpointMethod(serviceDef.Name, endpointDef, errorRegistryImportPath, errorParameterFormatJSON, false))
 	}
 	if serviceDef.HasHeaderAuth() || serviceDef.HasCookieAuth() {
 		// at least one endpoint uses authentication: define decorator structures
@@ -60,7 +60,7 @@ func writeServiceType(file *jen.Group, serviceDef *types.ServiceDefinition, erro
 		file.Add(astForNewServiceFuncWithAuth(serviceDef))
 		file.Add(astForClientStructDeclWithAuth(serviceDef))
 		for _, endpointDef := range serviceDef.Endpoints {
-			file.Add(astForEndpointMethod(serviceDef.Name, endpointDef, errorRegistryImportPath, true))
+			file.Add(astForEndpointMethod(serviceDef.Name, endpointDef, errorRegistryImportPath, errorParameterFormatJSON, true))
 		}
 
 		// Return true if all endpoints that require authentication are of the same auth type (header or cookie) and at least
@@ -213,7 +213,7 @@ func astForNewServiceFuncWithAuth(serviceDef *types.ServiceDefinition) *jen.Stat
 		))
 }
 
-func astForEndpointMethod(serviceName string, endpointDef *types.EndpointDefinition, errorRegistryImportPath string, withAuth bool) *jen.Statement {
+func astForEndpointMethod(serviceName string, endpointDef *types.EndpointDefinition, errorRegistryImportPath string, errorParameterFormatJSON bool, withAuth bool) *jen.Statement {
 	return jen.Func().
 		ParamsFunc(func(receiver *jen.Group) {
 			if withAuth {
@@ -233,12 +233,12 @@ func astForEndpointMethod(serviceName string, endpointDef *types.EndpointDefinit
 			if withAuth {
 				astForEndpointAuthMethodBodyFunc(methodBody, endpointDef)
 			} else {
-				astForEndpointMethodBodyFunc(methodBody, endpointDef, errorRegistryImportPath)
+				astForEndpointMethodBodyFunc(methodBody, endpointDef, errorRegistryImportPath, errorParameterFormatJSON)
 			}
 		})
 }
 
-func astForEndpointMethodBodyFunc(methodBody *jen.Group, endpointDef *types.EndpointDefinition, errorRegistryImportPath string) {
+func astForEndpointMethodBodyFunc(methodBody *jen.Group, endpointDef *types.EndpointDefinition, errorRegistryImportPath string, errorParameterFormatJSON bool) {
 	var (
 		hasReturnVal         = endpointDef.Returns != nil
 		returnsBinary        = hasReturnVal && (*endpointDef.Returns).IsBinary()
@@ -263,7 +263,7 @@ func astForEndpointMethodBodyFunc(methodBody *jen.Group, endpointDef *types.Endp
 	}
 
 	// build requestParams
-	astForEndpointMethodBodyRequestParams(methodBody, endpointDef, errorRegistryImportPath)
+	astForEndpointMethodBodyRequestParams(methodBody, endpointDef, errorRegistryImportPath, errorParameterFormatJSON)
 
 	// execute request
 	callStmt := jen.Id(clientReceiverName).Dot(clientStructFieldName).Dot(httpMethodTitleCase(endpointDef)).Call(
@@ -321,7 +321,7 @@ func astForEndpointMethodBodyFunc(methodBody *jen.Group, endpointDef *types.Endp
 	}
 }
 
-func astForEndpointMethodBodyRequestParams(methodBody *jen.Group, endpointDef *types.EndpointDefinition, errorRegistryImportPath string) {
+func astForEndpointMethodBodyRequestParams(methodBody *jen.Group, endpointDef *types.EndpointDefinition, errorRegistryImportPath string, errorParameterFormatJSON bool) {
 	methodBody.Var().Id(requestParamsVar).Index().Add(snip.CGRClientRequestParam())
 
 	// helper for the statement "requestParams = append(requestParams, {code})"
@@ -450,6 +450,10 @@ func astForEndpointMethodBodyRequestParams(methodBody *jen.Group, endpointDef *t
 	// errors
 	if errorRegistryImportPath != "" {
 		appendRequestParams(methodBody, snip.CGRClientWithRequestConjureErrorDecoder().Call(jen.Qual(errorRegistryImportPath, "Decoder").Call()))
+	}
+	// error parameter format
+	if errorParameterFormatJSON {
+		appendRequestParams(methodBody, snip.CGRClientWithConjureErrorParameterFormat().Call(snip.CGRErrorsConjureErrorParameterFormatJSON()))
 	}
 }
 

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -115,6 +115,7 @@ var (
 	CGRClientWithRPCMethodName                 = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRPCMethodName").Clone
 	CGRClientWithRawResponseBody               = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRawResponseBody").Clone
 	CGRClientWithRequestConjureErrorDecoder    = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRequestConjureErrorDecoder").Clone
+	CGRClientWithConjureErrorParameterFormat   = jen.Qual(cgr+"conjure-go-client/httpclient", "WithConjureErrorParameterFormatHeader").Clone
 	CGRClientWithRequestMethod                 = jen.Qual(cgr+"conjure-go-client/httpclient", "WithRequestMethod").Clone
 	CGRCodecsBinary                            = jen.Qual(cgr+"conjure-go-contract/codecs", "Binary").Clone
 	CGRCodecsJSON                              = jen.Qual(cgr+"conjure-go-contract/codecs", "JSON").Clone
@@ -134,6 +135,7 @@ var (
 	CGRErrorsNewInvalidArgument                = jen.Qual(cgr+"conjure-go-contract/errors", "NewInvalidArgument").Clone
 	CGRErrorsNewReflectTypeConjureErrorDecoder = jen.Qual(cgr+"conjure-go-contract/errors", "NewReflectTypeConjureErrorDecoder").Clone
 	CGRErrorsConjureErrorDecoder               = jen.Qual(cgr+"conjure-go-contract/errors", "ConjureErrorDecoder").Clone
+	CGRErrorsConjureErrorParameterFormatJSON   = jen.Qual(cgr+"conjure-go-contract/errors", "ConjureErrorParameterFormatJSON").Clone
 	CGRErrorsSerializableError                 = jen.Qual(cgr+"conjure-go-contract/errors", "SerializableError").Clone
 	CGRErrorsWrapWithInvalidArgument           = jen.Qual(cgr+"conjure-go-contract/errors", "WrapWithInvalidArgument").Clone
 	CGRErrorsWrapWithPermissionDenied          = jen.Qual(cgr+"conjure-go-contract/errors", "WrapWithPermissionDenied").Clone

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dave/jennifer v1.7.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.1.0
-	github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e
+	github.com/palantir/conjure-go-runtime/v3 v3.18.0
 	github.com/palantir/go-ptimports/v2 v2.50.0
 	github.com/palantir/godel-conjure-plugin/v6 v6.109.0
 	github.com/palantir/godel/pkg/products/v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dave/jennifer v1.7.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.1.0
-	github.com/palantir/conjure-go-runtime/v3 v3.15.0
+	github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e
 	github.com/palantir/go-ptimports/v2 v2.50.0
 	github.com/palantir/godel-conjure-plugin/v6 v6.109.0
 	github.com/palantir/godel/pkg/products/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/nwaples/rardecode/v2 v2.2.3 h1:qaVuy3ChZDbAQZshPLjHeNJKF3Cru8uo9jmgve
 github.com/nwaples/rardecode/v2 v2.2.3/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
-github.com/palantir/conjure-go-runtime/v3 v3.15.0 h1:SlzHG+3tc0HPGyTd7IKPPJZoHEHjFU5NAQWmF+kjE5I=
-github.com/palantir/conjure-go-runtime/v3 v3.15.0/go.mod h1:qJLvWYa0ZlyUpbDaHHe8SLnq56v7Vp5EwrXIdGqWVHo=
+github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e h1:RtkxXGji9iXoVZDJVhH/+xGhNo5kNSlADEIeYygq8Z0=
+github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e/go.mod h1:CfNsUq3sIw9DD/dOfFbIp7IjLNdKZcPuzfqOjEszeQk=
 github.com/palantir/go-metrics v1.1.1 h1:YL/UmptBjrC6iSCTVr7vfuIcjL0M359Da3/gBGNny10=
 github.com/palantir/go-metrics v1.1.1/go.mod h1:fRkuipBnsI4nD8Vd9UNcrUJvD8Y0wOJMSbicygcBrGs=
 github.com/palantir/go-ptimports/v2 v2.50.0 h1:3AsHcUFPvn4JxTNPcR4vPXKzh2DIJNVgLfeR7Svh1Cc=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/nwaples/rardecode/v2 v2.2.3 h1:qaVuy3ChZDbAQZshPLjHeNJKF3Cru8uo9jmgve
 github.com/nwaples/rardecode/v2 v2.2.3/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
-github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e h1:RtkxXGji9iXoVZDJVhH/+xGhNo5kNSlADEIeYygq8Z0=
-github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e/go.mod h1:CfNsUq3sIw9DD/dOfFbIp7IjLNdKZcPuzfqOjEszeQk=
+github.com/palantir/conjure-go-runtime/v3 v3.18.0 h1:rwmpO3yppa6S/HBwq9wPb20Ecm1iAPPCTyZWHIrOpXw=
+github.com/palantir/conjure-go-runtime/v3 v3.18.0/go.mod h1:CfNsUq3sIw9DD/dOfFbIp7IjLNdKZcPuzfqOjEszeQk=
 github.com/palantir/go-metrics v1.1.1 h1:YL/UmptBjrC6iSCTVr7vfuIcjL0M359Da3/gBGNny10=
 github.com/palantir/go-metrics v1.1.1/go.mod h1:fRkuipBnsI4nD8Vd9UNcrUJvD8Y0wOJMSbicygcBrGs=
 github.com/palantir/go-ptimports/v2 v2.50.0 h1:3AsHcUFPvn4JxTNPcR4vPXKzh2DIJNVgLfeR7Svh1Cc=

--- a/integration_test/testgenerated/client/api/services.conjure.go
+++ b/integration_test/testgenerated/client/api/services.conjure.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/palantir/pkg/rid"
 	werror "github.com/palantir/witchcraft-go-error"
 )
@@ -39,6 +40,7 @@ func (c *testServiceClient) Echo(ctx context.Context) error {
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("Echo"))
 	requestParams = append(requestParams, httpclient.WithPathf("/echo"))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "echo failed")
 	}
@@ -49,6 +51,7 @@ func (c *testServiceClient) PathParam(ctx context.Context, paramArg string) erro
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParam"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "pathParam failed")
 	}
@@ -59,6 +62,7 @@ func (c *testServiceClient) PathParamAlias(ctx context.Context, paramArg StringA
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamAlias"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/alias/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "pathParamAlias failed")
 	}
@@ -69,6 +73,7 @@ func (c *testServiceClient) PathParamRid(ctx context.Context, paramArg rid.Resou
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamRid"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/rid/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "pathParamRid failed")
 	}
@@ -79,6 +84,7 @@ func (c *testServiceClient) PathParamRidAlias(ctx context.Context, paramArg RidA
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamRidAlias"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/rid/alias/%s", url.PathEscape(fmt.Sprint(paramArg))))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "pathParamRidAlias failed")
 	}
@@ -89,6 +95,7 @@ func (c *testServiceClient) PathParamOrder(ctx context.Context, paramLastArg str
 	var requestParams []httpclient.RequestParam
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("PathParamOrder"))
 	requestParams = append(requestParams, httpclient.WithPathf("/path/order/%s/%s/%s", url.PathEscape(fmt.Sprint(param1Arg)), url.PathEscape(fmt.Sprint(param2Arg)), url.PathEscape(fmt.Sprint(paramLastArg))))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "pathParamOrder failed")
 	}
@@ -101,6 +108,7 @@ func (c *testServiceClient) Bytes(ctx context.Context) (CustomObject, error) {
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("Bytes"))
 	requestParams = append(requestParams, httpclient.WithPathf("/bytes"))
 	requestParams = append(requestParams, httpclient.WithJSONResponse(&returnVal))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return *new(CustomObject), werror.WrapWithContextParams(ctx, err, "bytes failed")
 	}
@@ -115,6 +123,7 @@ func (c *testServiceClient) Binary(ctx context.Context) (io.ReadCloser, error) {
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("Binary"))
 	requestParams = append(requestParams, httpclient.WithPathf("/binary"))
 	requestParams = append(requestParams, httpclient.WithRawResponseBody())
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	resp, err := c.client.Get(ctx, requestParams...)
 	if err != nil {
 		return nil, werror.WrapWithContextParams(ctx, err, "binary failed")
@@ -127,6 +136,7 @@ func (c *testServiceClient) MaybeBinary(ctx context.Context) (*io.ReadCloser, er
 	requestParams = append(requestParams, httpclient.WithRPCMethodName("MaybeBinary"))
 	requestParams = append(requestParams, httpclient.WithPathf("/optional/binary"))
 	requestParams = append(requestParams, httpclient.WithRawResponseBody())
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	resp, err := c.client.Get(ctx, requestParams...)
 	if err != nil {
 		return nil, werror.WrapWithContextParams(ctx, err, "maybeBinary failed")
@@ -146,6 +156,7 @@ func (c *testServiceClient) Query(ctx context.Context, queryArg *StringAlias) er
 		queryParams.Set("query", fmt.Sprint(*queryArg))
 	}
 	requestParams = append(requestParams, httpclient.WithQueryValues(queryParams))
+	requestParams = append(requestParams, httpclient.WithConjureErrorParameterFormatHeader(errors.ConjureErrorParameterFormatJSON))
 	if _, err := c.client.Get(ctx, requestParams...); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "query failed")
 	}

--- a/integration_test/testgenerated/client/clientparam_test.go
+++ b/integration_test/testgenerated/client/clientparam_test.go
@@ -62,6 +62,33 @@ func TestHeaderParams(t *testing.T) {
 	assert.True(t, called)
 }
 
+// TestErrorParameterFormatHeader verifies that a client generated with ErrorParameterFormatJSON
+// enabled sends the "Accept-Conjure-Error-Parameter-Format: JSON" header on every request without
+// the caller having to configure it. The client package is generated with ErrorParameterFormatJSON
+// set (see integration_test/testgenerated/generate.go).
+func TestErrorParameterFormatHeader(t *testing.T) {
+	called := false
+	r := httprouter.New()
+	r.GET("/echo", httprouter.Handle(func(rw http.ResponseWriter, req *http.Request, params httprouter.Params) {
+		called = true
+		assert.Equal(t, "JSON", req.Header.Get("Accept-Conjure-Error-Parameter-Format"))
+		rw.WriteHeader(http.StatusOK)
+	}))
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	httpClient, err := httpclient.NewClient(
+		httpclient.WithUserAgent("TestErrorParameterFormatHeader"),
+		httpclient.WithBaseURLs([]string{server.URL}),
+	)
+	require.NoError(t, err)
+
+	client := api.NewTestServiceClient(httpClient)
+	err = client.Echo(context.Background())
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
 func TestPathParam(t *testing.T) {
 	const (
 		wantParam        = "var/conf/install.yml"

--- a/integration_test/testgenerated/generate.go
+++ b/integration_test/testgenerated/generate.go
@@ -29,28 +29,34 @@ import (
 )
 
 func main() {
-	for importPath, outDir := range definitions {
-		if err := run(importPath, outDir); err != nil {
-			fmt.Printf("Error: %s: %+v\n", outDir, err)
+	for importPath, cfg := range definitions {
+		if err := run(importPath, cfg); err != nil {
+			fmt.Printf("Error: %s: %+v\n", cfg.outDir, err)
 			os.Exit(1)
 		}
 	}
 }
 
-var definitions = map[string]string{
-	"auth/auth-service.yml":        "auth",
-	"binary/binary-service.yml":    "binary",
-	"cli/cli-service.yml":          "cli",
-	"client/client-service.yml":    "client",
-	"errors/errors.yml":            "errors",
-	"imports/imports.yml":          "imports",
-	"objects/objects.yml":          "objects",
-	"post/post-service.yml":        "post",
-	"queryparam/query-service.yml": "queryparam",
-	"server/server-service.yml":    "server",
+// definition describes how a single Conjure definition should be generated.
+type definition struct {
+	outDir                   string
+	errorParameterFormatJSON bool
 }
 
-func run(in, out string) error {
+var definitions = map[string]definition{
+	"auth/auth-service.yml":        {outDir: "auth"},
+	"binary/binary-service.yml":    {outDir: "binary"},
+	"cli/cli-service.yml":          {outDir: "cli"},
+	"client/client-service.yml":    {outDir: "client", errorParameterFormatJSON: true},
+	"errors/errors.yml":            {outDir: "errors"},
+	"imports/imports.yml":          {outDir: "imports"},
+	"objects/objects.yml":          {outDir: "objects"},
+	"post/post-service.yml":        {outDir: "post"},
+	"queryparam/query-service.yml": {outDir: "queryparam"},
+	"server/server-service.yml":    {outDir: "server"},
+}
+
+func run(in string, def definition) error {
 	irBytes, err := conjureircli.InputPathToIR(in)
 	if err != nil {
 		return err
@@ -60,10 +66,11 @@ func run(in, out string) error {
 		return err
 	}
 	return conjure.Generate(conjureDef, conjure.OutputConfiguration{
-		OutputDir:            out,
-		GenerateServer:       true,
-		GenerateFuncsVisitor: true,
-		GenerateCLI:          true,
-		ExportErrorDecoder:   true,
+		OutputDir:                def.outDir,
+		GenerateServer:           true,
+		GenerateFuncsVisitor:     true,
+		GenerateCLI:              true,
+		ExportErrorDecoder:       true,
+		ErrorParameterFormatJSON: def.errorParameterFormatJSON,
 	})
 }

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/authn.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/authn.go
@@ -17,10 +17,12 @@ package httpclient
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/palantir/pkg/refreshable/v2"
+	"golang.org/x/net/idna"
 )
 
 // TokenProvider accepts a context and returns either:
@@ -44,7 +46,7 @@ func (h *authTokenMiddleware) RoundTrip(req *http.Request, next http.RoundTrippe
 		return nil, err
 	}
 	if token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		setAuthorizationHeader(req, "Bearer "+token)
 	}
 	return next.RoundTrip(req)
 }
@@ -79,13 +81,98 @@ type BasicAuthOptionalProvider func(context.Context) (*BasicAuth, error)
 func newBasicAuthMiddlewareFromRefreshable(auth refreshable.Refreshable[*BasicAuth]) Middleware {
 	return MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 		if basicAuth := auth.Current(); basicAuth != nil {
-			setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+			setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		}
 		return next.RoundTrip(req)
 	})
 }
 
-func setBasicAuth(h http.Header, username, password string) {
+func setBasicAuth(req *http.Request, username, password string) {
+	setAuthorizationHeader(req, basicAuthValue(username, password))
+}
+
+func basicAuthValue(username, password string) string {
 	basicAuthBytes := []byte(username + ":" + password)
-	h.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(basicAuthBytes))
+	return "Basic " + base64.StdEncoding.EncodeToString(basicAuthBytes)
+}
+
+// setAuthorizationHeader sets the Authorization header on req to value, unless following
+// redirects has taken req to a host that is not the same as (or a subdomain of) the
+// original request host.
+func setAuthorizationHeader(req *http.Request, value string) {
+	if !authHeaderAllowedOnRedirect(req) {
+		return
+	}
+	req.Header.Set("Authorization", value)
+}
+
+// authHeaderAllowedOnRedirect reports whether Authorization credentials may be attached to req.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/client.go#L688-L692
+func authHeaderAllowedOnRedirect(req *http.Request) bool {
+	if req.Response == nil {
+		// Initial request, not a redirect, credentials are always allowed.
+		return true
+	}
+	origin := originRequest(req)
+	if origin.URL == nil {
+		return true
+	}
+	originHost := idnaASCIIFromURL(origin.URL)
+	// Require every redirect to remain on the same host, or a subdomain of, the original host.
+	for r := req; r != origin; {
+		if r.URL == nil || !isDomainOrSubdomain(idnaASCIIFromURL(r.URL), originHost) {
+			return false
+		}
+		if r.Response == nil || r.Response.Request == nil {
+			break
+		}
+		r = r.Response.Request
+	}
+	return true
+}
+
+// originRequest walks the redirect chain back to the original request (i.e. the first request that
+// was not produced by following a redirect).
+func originRequest(req *http.Request) *http.Request {
+	r := req
+	for r.Response != nil && r.Response.Request != nil {
+		r = r.Response.Request
+	}
+	return r
+}
+
+// idnaASCIIFromURL returns the host of u in its IDNA ASCII form.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/transport.go#L3024-L3030
+func idnaASCIIFromURL(u *url.URL) string {
+	addr := u.Hostname()
+	if v, err := idna.Lookup.ToASCII(addr); err == nil {
+		addr = v
+	}
+	return addr
+}
+
+// isDomainOrSubdomain reports whether sub is a subdomain (or exact match) of the parent domain.
+// It is copied verbatim from net/http's unexported isDomainOrSubdomain to match the standard library's
+// redirect header-stripping semantics exactly.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/client.go#L1028-L1045
+func isDomainOrSubdomain(sub, parent string) bool {
+	if sub == parent {
+		return true
+	}
+	// If sub contains a :, it's probably an IPv6 address (and is definitely not a hostname).
+	// Don't check the suffix in this case, to avoid matching the contents of a IPv6 zone.
+	// For example, "::1%.www.example.com" is not a subdomain of "www.example.com".
+	if strings.ContainsAny(sub, ":%") {
+		return false
+	}
+	// If sub is "foo.example.com" and parent is "example.com",
+	// that means sub must end in "."+parent.
+	// Do it without allocating.
+	if !strings.HasSuffix(sub, parent) {
+		return false
+	}
+	return sub[len(sub)-len(parent)-1] == '.'
 }

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/client_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/client_params.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/refreshable/v2"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -173,6 +174,12 @@ func WithAuthTokenProvider(provideToken TokenProvider) ClientOrHTTPClientParam {
 // WithUserAgent sets the User-Agent header.
 func WithUserAgent(userAgent string) ClientOrHTTPClientParam {
 	return WithSetHeader("User-Agent", userAgent)
+}
+
+// WithConjureErrorParameterFormat sets the "Accept-Conjure-Error-Parameter-Format" header on
+// every request so that conjure servers serialize error parameters in the requested format.
+func WithConjureErrorParameterFormat(format errors.ConjureErrorParameterFormat) ClientOrHTTPClientParam {
+	return WithSetHeader(errors.AcceptConjureErrorParameterFormatHeader, string(format))
 }
 
 // WithOverrideRequestHost overrides the request Host from the default URL.Host

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/client_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/client_params.go
@@ -630,7 +630,7 @@ func WithErrorDecoder(errorDecoder ErrorDecoder) ClientParam {
 // password.
 func WithBasicAuth(user, password string) ClientOrHTTPClientParam {
 	return WithInnerMiddleware(MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-		setBasicAuth(req.Header, user, password)
+		setBasicAuth(req, user, password)
 		return next.RoundTrip(req)
 	}))
 }
@@ -643,7 +643,7 @@ func WithBasicAuthProvider(provider BasicAuthProvider) ClientOrHTTPClientParam {
 		if err != nil {
 			return nil, err
 		}
-		setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+		setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		return next.RoundTrip(req)
 	}))
 }
@@ -659,7 +659,7 @@ func WithBasicAuthOptionalProvider(provider BasicAuthOptionalProvider) ClientOrH
 			return nil, err
 		}
 		if basicAuth != nil {
-			setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+			setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		}
 		return next.RoundTrip(req)
 	}))

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/request_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/request_params.go
@@ -72,6 +72,12 @@ func WithHeader(key, value string) RequestParam {
 	})
 }
 
+// WithConjureErrorParameterFormatHeader sets the "Accept-Conjure-Error-Parameter-Format"
+// header on a request so that conjure servers serialize error parameters in the requested format.
+func WithConjureErrorParameterFormatHeader(format errors.ConjureErrorParameterFormat) RequestParam {
+	return WithHeader(errors.AcceptConjureErrorParameterFormatHeader, string(format))
+}
+
 // WithQueryValues sets a header on a request.
 func WithQueryValues(query url.Values) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/request_params.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/request_params.go
@@ -221,7 +221,7 @@ func WithRequestErrorDecoder(errorDecoder ErrorDecoder) RequestParam {
 // username and password for this request only and takes precedence over any client-scoped authorization.
 func WithRequestBasicAuth(username, password string) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		setBasicAuth(b.headers, username, password)
+		b.headers.Set("Authorization", basicAuthValue(username, password))
 		return nil
 	})
 }

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors/error_parameter_format.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors/error_parameter_format.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+const (
+	// AcceptConjureErrorParameterFormatHeader is the request header a client sends to negotiate
+	// the serialization format of Conjure error parameters. When the value is recognized by
+	// the server, the server serializes error parameters in that format instead of the legacy form.
+	//
+	// The header is a best-effort hint: servers that do not understand it ignore it and continue
+	// to send the legacy form, so error decoding must remain tolerant of both forms.
+	AcceptConjureErrorParameterFormatHeader = "Accept-Conjure-Error-Parameter-Format"
+)
+
+// ConjureErrorParameterFormat is the value of the Accept-Conjure-Error-Parameter-Format header.
+type ConjureErrorParameterFormat string
+
+const (
+	// ConjureErrorParameterFormatJSON requests that the server serialize Conjure error parameters
+	// as native JSON values keyed by their declared Conjure type, rather than the legacy string form.
+	ConjureErrorParameterFormatJSON ConjureErrorParameterFormat = "JSON"
+)

--- a/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors/error_type_registry.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors/error_type_registry.go
@@ -74,18 +74,18 @@ func (d *ReflectTypeConjureErrorDecoder) RegisterErrorType(name string, typ refl
 }
 
 func (d *ReflectTypeConjureErrorDecoder) DecodeConjureError(errorName string, body []byte) (Error, error) {
-	typ, ok := d.registry[errorName]
-	if !ok {
-		// Unrecognized error name, fall back to genericError
-		typ = reflect.TypeFor[genericError]()
+	if typ, ok := d.registry[errorName]; ok {
+		instance := reflect.New(typ).Interface()
+		if err := codecs.JSON.Unmarshal(body, &instance); err == nil {
+			// RegisterErrorType guarantees *typ implements Error, so this assertion always holds.
+			return instance.(Error), nil
+		}
+		// The registered type failed to decode the body. Rather than discard the conjure error, fall through to a genericError,
+		// which decodes parameters into a map[string]any and preserves the error name, code, instance ID, and raw parameters.
 	}
-	instance := reflect.New(typ).Interface()
-	if err := codecs.JSON.Unmarshal(body, &instance); err != nil {
-		return nil, werror.Wrap(err, "failed to unmarshal body using registered type", werror.SafeParam("type", typ.String()))
-	}
-	cerr, ok := instance.(Error)
-	if !ok {
-		return nil, werror.Error("unmarshaled type does not implement errors.Error interface", werror.SafeParam("type", typ.String()))
+	var cerr genericError
+	if err := codecs.JSON.Unmarshal(body, &cerr); err != nil {
+		return nil, werror.Wrap(err, "failed to unmarshal body as generic conjure error")
 	}
 	return cerr, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -102,7 +102,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v3 v3.15.0
+# github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e
 ## explicit; go 1.26.0
 github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -102,7 +102,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v3 v3.15.1-0.20260615194028-9bc18ed2425e
+# github.com/palantir/conjure-go-runtime/v3 v3.18.0
 ## explicit; go 1.26.0
 github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal


### PR DESCRIPTION
## Before this PR
There was no ability to set the JSON error parameter format for generated clients.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add ErrorParameterFormatJSON option
==COMMIT_MSG==

When `OutputConfiguration.ErrorParameterFormatJSON` is set to true, all requests will set the `Accept-Conjure-Error-Parameter-Format: JSON` header so that servers serialize error parameters as JSON. This is opt-in only since there could be behavior that users depend on with the legacy error parameter format. Servers that do not support this treat this header as a noop.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

