### PR TITLE
Emit conjuretype registry metadata for generated enums and unions

### DIFF
--- a/conjure/enumwriter.go
+++ b/conjure/enumwriter.go
@@ -37,6 +37,27 @@ func writeEnumType(file *jen.Group, enumDef *types.EnumType) {
 	file.Add(astForEnumStringMethod(enumDef.Name))
 	file.Add(astForEnumMarshalText(enumDef.Name))
 	file.Add(astForEnumUnmarshalText(enumDef.Name, enumDef.Values))
+	file.Add(astForEnumConjureTypeRegistration(enumDef.Name, enumDef.Values))
+}
+
+// astForEnumConjureTypeRegistration emits an init() that records this type in the
+// shared conjuretype registry, so reflection tools can discover that it is a
+// conjure enum and enumerate its known values. Nothing is added to the type's
+// own method set, so this metadata is invisible to autocomplete.
+func astForEnumConjureTypeRegistration(typeName string, values []*types.Field) *jen.Statement {
+	return jen.Func().Id("init").Params().Block(
+		snip.ConjureTypeRegister().Call(
+			snip.ReflectTypeFor().Index(jen.Id(typeName)).Call(),
+			snip.ConjureTypeEnumDescriptor().Values(
+				jen.Id("Name").Op(":").Lit(typeName),
+				jen.Id("Values").Op(":").Index().String().ValuesFunc(func(vals *jen.Group) {
+					for _, valDef := range values {
+						vals.Lit(valDef.Name)
+					}
+				}),
+			),
+		),
+	)
 }
 
 func astForEnumTypeDecls(typeName string) *jen.Statement {

--- a/conjure/snip/imports.go
+++ b/conjure/snip/imports.go
@@ -23,6 +23,9 @@ const (
 	cgr = pal + "conjure-go-runtime/v3/"
 	wgl = pal + "witchcraft-go-logging/"
 	wgr = pal + "witchcraft-go-router/"
+	// cjt is the import path of the shared conjure type-metadata registry.
+	// Prototype path; in production this package would live under conjure-go-runtime.
+	cjt = pal + "conjuretype"
 )
 
 // ImportsToPackageNames returns a map of import paths to package names for use with jennifer.
@@ -55,6 +58,7 @@ func ImportsToPackageNames() map[string]string {
 		"gopkg.in/yaml.v3":                     "yaml",
 		"github.com/spf13/cobra":               "cobra",
 		"github.com/spf13/pflag":               "pflag",
+		cjt:                                    "conjuretype",
 	}
 }
 
@@ -88,6 +92,7 @@ var (
 	OSReadFile          = jen.Qual("os", "ReadFile").Clone
 	OSOpen              = jen.Qual("os", "Open").Clone
 	ReflectTypeOf       = jen.Qual("reflect", "TypeOf").Clone
+	ReflectTypeFor      = jen.Qual("reflect", "TypeFor").Clone
 	StringsToUpper      = jen.Qual("strings", "ToUpper").Clone
 	StringsHasPrefix    = jen.Qual("strings", "HasPrefix").Clone
 	StringsTrimSpace    = jen.Qual("strings", "TrimSpace").Clone
@@ -162,6 +167,12 @@ var (
 	UUIDUUID                       = jen.Qual(pal+"pkg/uuid", "UUID").Clone
 	UUIDNewUUID                    = jen.Qual(pal+"pkg/uuid", "NewUUID").Clone
 	UUIDParseUUID                  = jen.Qual(pal+"pkg/uuid", "ParseUUID").Clone
+
+	// conjuretype (type-metadata registry) imports
+	ConjureTypeRegister        = jen.Qual(cjt, "Register").Clone
+	ConjureTypeUnionDescriptor = jen.Qual(cjt, "UnionDescriptor").Clone
+	ConjureTypeEnumDescriptor  = jen.Qual(cjt, "EnumDescriptor").Clone
+	ConjureTypeMember          = jen.Qual(cjt, "Member").Clone
 
 	WerrorErrorContext    = jen.Qual(pal+"witchcraft-go-error", "ErrorWithContextParams").Clone
 	WerrorFormat          = jen.Qual(pal+"witchcraft-go-error", "Format").Clone

--- a/conjure/unionwriter.go
+++ b/conjure/unionwriter.go
@@ -44,6 +44,33 @@ func writeUnionType(file *jen.Group, unionDef *types.UnionType, genAcceptFuncs b
 	unionVisitorFuncs(file, unionDef, genAcceptFuncs)
 	// Declare New*From* constructor functions
 	unionConstructorFuncs(file, unionDef)
+	// Register type metadata for reflection-based discovery.
+	file.Add(astForUnionConjureTypeRegistration(unionDef))
+}
+
+// astForUnionConjureTypeRegistration emits an init() that records this type in the
+// shared conjuretype registry. The descriptor carries each variant's name and its
+// actual Go type (via reflect.TypeFor), so a reflection tool can discover that the
+// type is a conjure union, enumerate its variants, and recurse into their types.
+// Nothing is added to the type's own method set, keeping this invisible to autocomplete.
+func astForUnionConjureTypeRegistration(unionDef *types.UnionType) *jen.Statement {
+	return jen.Func().Id("init").Params().Block(
+		snip.ConjureTypeRegister().Call(
+			snip.ReflectTypeFor().Index(jen.Id(unionDef.Name)).Call(),
+			snip.ConjureTypeUnionDescriptor().Values(
+				jen.Id("Name").Op(":").Lit(unionDef.Name),
+				jen.Id("Members").Op(":").Index().Add(snip.ConjureTypeMember()).ValuesFunc(func(members *jen.Group) {
+					for _, fieldDef := range unionDef.Fields {
+						members.Values(
+							jen.Id("Name").Op(":").Lit(fieldDef.Name),
+							jen.Id("Type").Op(":").Add(snip.ReflectTypeFor()).Index(fieldDef.Type.Code()).Call(),
+							jen.Id("Optional").Op(":").Lit(fieldDef.Type.IsOptional()),
+						)
+					}
+				}),
+			),
+		),
+	)
 }
 
 func unionSerializationFuncs(file *jen.Group, unionDef *types.UnionType) {


### PR DESCRIPTION
Generated enums and unions now register a descriptor in a shared `conjuretype` registry from an `init()` function. This lets reflection tools discover, from a `reflect.Type` alone, that a type was generated by Conjure, which kind it is, and — for unions — its variants and their real `reflect.Type` values (recursable). Nothing is added to the generated type's own method set, so this metadata stays invisible to autocomplete.

- conjure/snip/imports.go: conjuretype import path + reflect.TypeFor and descriptor snippet refs.
- conjure/enumwriter.go: emit init() registering an EnumDescriptor.
- conjure/unionwriter.go: emit init() registering a UnionDescriptor with per-variant Member{Name, Type, Optional}.

Prototype: the emitted code imports github.com/palantir/conjuretype; in production that package would live under conjure-go-runtime. Testdata is not regenerated here because the runtime package is not yet published.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

