### PR TITLE
fix: Format generated files without goimports' import resolution

### DIFF
--- a/conjure/conjure.go
+++ b/conjure/conjure.go
@@ -19,8 +19,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/dave/jennifer/jen"
 	"github.com/palantir/conjure-go/v7/conjure-api/conjure/spec"
@@ -58,7 +61,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 			return nil, errors.Wrapf(err, "failed to determine import path for error registry package")
 		}
 		errorRegistryJenFile := jen.NewFilePathName(errorRegistryImportPath, path.Base(errorRegistryImportPath))
-		errorRegistryJenFile.ImportNames(snip.ImportsToPackageNames())
+		setImportNames(errorRegistryJenFile, snip.ImportsToPackageNames())
 		writeErrorRegistryFile(errorRegistryJenFile.Group)
 		errorRegistryOutputDir, err := types.GetOutputDirectoryForGoPackage(cfg.OutputDir, errorRegistryImportPath)
 		if err != nil {
@@ -72,7 +75,7 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 				return nil, errors.Wrapf(err, "failed to determine import path for error decoder package")
 			}
 			errorDecoderJenFile := jen.NewFilePathName(errorDecoderImportPath, path.Base(errorDecoderImportPath))
-			errorDecoderJenFile.ImportNames(snip.ImportsToPackageNames())
+			setImportNames(errorDecoderJenFile, snip.ImportsToPackageNames())
 			errorDecoderJenFile.ImportAlias(errorRegistryImportPath, "internalconjureerrors")
 			writeErrorDecoderExportFile(errorDecoderJenFile.Group, errorRegistryImportPath)
 			errorDecoderOutputDir, err := types.GetOutputDirectoryForGoPackage(cfg.OutputDir, errorDecoderImportPath)
@@ -196,16 +199,12 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 
 func newJenFile(pkg types.ConjurePackage, def *types.ConjureDefinition, errorRegistryImportPath string) *jen.File {
 	f := jen.NewFilePathName(pkg.ImportPath, pkg.PackageName)
-	f.ImportNames(snip.ImportsToPackageNames())
+	setImportNames(f, snip.ImportsToPackageNames())
 	for _, conjurePackage := range def.Packages {
-		if packageSuffixRequiresAlias(conjurePackage.ImportPath) {
-			f.ImportAlias(conjurePackage.ImportPath, conjurePackage.PackageName)
-		} else {
-			f.ImportName(conjurePackage.ImportPath, conjurePackage.PackageName)
-		}
+		setImportName(f, conjurePackage.ImportPath, conjurePackage.PackageName)
 	}
 	if errorRegistryImportPath != "" {
-		f.ImportName(errorRegistryImportPath, path.Base(errorRegistryImportPath))
+		setImportName(f, errorRegistryImportPath, path.Base(errorRegistryImportPath))
 	}
 	return f
 }
@@ -227,6 +226,49 @@ func newRawFile(filePath string, bytes []byte) *OutputFile {
 	}
 }
 
-func packageSuffixRequiresAlias(importPath string) bool {
-	return regexp.MustCompile(`/v[0-9]+$`).MatchString(importPath)
+// setImportNames registers the package name of each import path with f.
+func setImportNames(f *jen.File, packageNames map[string]string) {
+	for importPath, packageName := range packageNames {
+		setImportName(f, importPath, packageName)
+	}
+}
+
+// setImportName registers packageName as the name of importPath with f, stating it as an explicit alias where an
+// unaliased import would leave a reader guessing.
+func setImportName(f *jen.File, importPath, packageName string) {
+	if packageName == importPathToAssumedName(importPath) {
+		f.ImportName(importPath, packageName)
+	} else {
+		f.ImportAlias(importPath, packageName)
+	}
+}
+
+// importPathToAssumedName returns the package name a reader infers from an import path alone. It is a copy of
+// golang.org/x/tools/internal/imports.ImportPathToAssumedName, which is not importable from outside x/tools; matching
+// it exactly is what lets generated files skip goimports' import-resolution pass and still come out unchanged.
+//
+// Copy it verbatim rather than tidying it. The "go-" trim in particular is an undocumented heuristic for repositories
+// named go-foo that declare package foo; it is unreachable for the import paths conjure-go emits today, but dropping
+// it would make this disagree with goimports the first time one appears.
+func importPathToAssumedName(importPath string) string {
+	base := path.Base(importPath)
+	if strings.HasPrefix(base, "v") {
+		if _, err := strconv.Atoi(base[1:]); err == nil {
+			if dir := path.Dir(importPath); dir != "." {
+				base = path.Base(dir)
+			}
+		}
+	}
+	base = strings.TrimPrefix(base, "go-")
+	if i := strings.IndexFunc(base, notIdentifier); i >= 0 {
+		base = base[:i]
+	}
+	return base
+}
+
+func notIdentifier(ch rune) bool {
+	return !('a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' ||
+		'0' <= ch && ch <= '9' ||
+		ch == '_' ||
+		ch >= utf8.RuneSelf && (unicode.IsLetter(ch) || unicode.IsDigit(ch)))
 }

--- a/conjure/imports_test.go
+++ b/conjure/imports_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conjure
+
+import (
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/palantir/conjure-go/v7/conjure/snip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportPathToAssumedName(t *testing.T) {
+	for _, tc := range []struct {
+		importPath string
+		want       string
+	}{
+		{"github.com/palantir/pkg/safejson", "safejson"},
+		{"github.com/palantir/witchcraft-go-error", "witchcraft"},
+		{"github.com/palantir/witchcraft-go-logging/wlog-zap", "wlog"},
+		{"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient", "httpclient"},
+		{"github.com/palantir/api/v3", "api"},
+		{"github.com/hashicorp/go-multierror", "multierror"},
+		{"example.com/conjure/com/palantir/bar_foo", "bar_foo"},
+		{"gopkg.in/yaml.v3", "yaml"},
+	} {
+		assert.Equal(t, tc.want, importPathToAssumedName(tc.importPath), "import path %s", tc.importPath)
+	}
+}
+
+// TestSetImportNameRendersExplicitAlias verifies that an import whose package name is not inferable from its path is
+// rendered with an explicit alias. Generated files are formatted without goimports' import-resolution pass, so
+// jennifer is the only thing that can supply the alias.
+func TestSetImportNameRendersExplicitAlias(t *testing.T) {
+	const werrorPath = "github.com/palantir/witchcraft-go-error"
+
+	for _, tc := range []struct {
+		name       string
+		importPath string
+		wantImport string
+	}{
+		{
+			name:       "package name not inferable from path",
+			importPath: werrorPath,
+			wantImport: `werror "` + werrorPath + `"`,
+		},
+		{
+			name:       "package name inferable from path",
+			importPath: "github.com/palantir/pkg/safejson",
+			wantImport: `"github.com/palantir/pkg/safejson"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := jen.NewFilePathName("example.com/testpkg", "testpkg")
+			setImportNames(f, snip.ImportsToPackageNames())
+			f.Var().Id("_").Op("=").Qual(tc.importPath, "Something")
+
+			rendered, err := newGoFile("/tmp/test.go", f).Render()
+			require.NoError(t, err)
+			assert.Contains(t, string(rendered), tc.wantImport)
+		})
+	}
+}

--- a/conjure/outputs.go
+++ b/conjure/outputs.go
@@ -56,18 +56,29 @@ func (f *OutputFile) Render() ([]byte, error) {
 	return bytes, nil
 }
 
+// newlineAfterBrace matches a closing brace at the start of a line that is immediately followed by another declaration.
+var newlineAfterBrace = regexp.MustCompile(`(\n}\n)(\S)`)
+
+// ptimportsOptions formats the rendered source without letting goimports add or remove imports.
+//
+// jennifer emits an import for every qualified reference it renders and for nothing else, so there is never anything
+// for goimports to resolve. Leaving resolution enabled is not just redundant, it is expensive: each call builds a fresh
+// resolver that shells out to "go env" and reads the whole module-cache index (tens of MB) before it can conclude the
+// file is already complete, which dominates generation time for large IRs.
+var ptimportsOptions = &ptimports.Options{Refactor: true, FormatOnly: true}
+
 func renderJenFile(f *jen.File) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	if err := f.Render(buf); err != nil {
 		return nil, errors.Wrapf(err, "failed to generate Go source")
 	}
 
-	goFileSrc, err := ptimports.Process("", buf.Bytes(), &ptimports.Options{Refactor: true})
+	goFileSrc, err := ptimports.Process("", buf.Bytes(), ptimportsOptions)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to run ptimports on generated Go source")
 	}
 	// add extra newline after braces
-	goFileSrc = regexp.MustCompile(`(\n}\n)(\S)`).ReplaceAll(goFileSrc, []byte("$1\n$2"))
+	goFileSrc = newlineAfterBrace.ReplaceAll(goFileSrc, []byte("$1\n$2"))
 
 	return goFileSrc, nil
 }


### PR DESCRIPTION
Each ptimports call previously built a fresh resolver that shelled out to "go env" and read the entire module-cache index before concluding the file was already complete. Regenerating an 11-project, 617-file tree drops from 2m25s to 9s. Generated output is byte-identical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go/1013)
<!-- Reviewable:end -->
